### PR TITLE
Rename crate to `fishfight`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "fishgame"
+name = "fishfight"
 version = "0.2.0"
 dependencies = [
  "macroquad",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fishgame"
+name = "fishfight"
 version = "0.2.0"
 authors = ["Fedor Logachev <not.fl3@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
Hello,

Recently I came across your project, tried it out and it's very fun :fish:

One thing I realized is that the binary was named "fishgame" and I thought this was supposed to be consistent with the project/organization name. So this PR basically renames the Rust crate to "fishfight". Feel free to close the PR if the initial naming was intentional.

Thank you!
