### PR TITLE
Set the window title to "FishFight"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -305,7 +305,7 @@ async fn game(map: &str, game_type: GameType) {
 
 fn window_conf() -> Conf {
     Conf {
-        window_title: "FISH".to_owned(),
+        window_title: "FishFight".to_owned(),
         high_dpi: false,
         window_width: 955,
         window_height: 600,


### PR DESCRIPTION
I thought it would be more appropriate to rename the window to match the project's name.
