### PR TITLE
Support specifying the assets directory at runtime

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -24,15 +24,19 @@ pub struct GuiResources {
 }
 
 impl GuiResources {
-    pub async fn load() -> GuiResources {
+    pub async fn load(assets_dir: &str) -> GuiResources {
         let mut levels = vec![];
-        let levels_str = load_string("assets/levels/levels.toml").await.unwrap();
+        let levels_str = load_string(&format!("{}/assets/levels/levels.toml", assets_dir))
+            .await
+            .unwrap();
         let toml = nanoserde::TomlParser::parse(&levels_str).unwrap();
 
         for level in toml["level"].arr() {
             levels.push(Level {
-                map: level["map"].str().to_owned(),
-                preview: load_texture(level["preview"].str()).await.unwrap(),
+                map: format!("{}/{}", assets_dir, level["map"].str()),
+                preview: load_texture(&format!("{}/{}", assets_dir, level["preview"].str()))
+                    .await
+                    .unwrap(),
                 size: 0.,
             })
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use macroquad_platformer::{Tile, World as CollisionWorld};
 use particles::{Emitter, EmittersCache};
 
 use std::collections::HashMap;
+use std::env;
 
 mod capabilities;
 mod gui;
@@ -65,47 +66,77 @@ struct Resources {
 
 impl Resources {
     // TODO: fix macroquad error type here
-    async fn new(map: &str) -> Result<Resources, macroquad::prelude::FileError> {
-        let tileset = load_texture("assets/tileset.png").await?;
+    async fn new(map: &str, assets_dir: &str) -> Result<Resources, macroquad::prelude::FileError> {
+        let tileset = load_texture(&format!("{}/assets/tileset.png", assets_dir)).await?;
         tileset.set_filter(FilterMode::Nearest);
 
-        let decorations = load_texture("assets/decorations1.png").await?;
+        let decorations = load_texture(&format!("{}/assets/decorations1.png", assets_dir)).await?;
         decorations.set_filter(FilterMode::Nearest);
 
-        let whale_green = load_texture("assets/Whale/Whale(76x66)(Green).png").await?;
+        let whale_green = load_texture(&format!(
+            "{}/assets/Whale/Whale(76x66)(Green).png",
+            assets_dir
+        ))
+        .await?;
         whale_green.set_filter(FilterMode::Nearest);
 
-        let whale_blue = load_texture("assets/Whale/Whale(76x66)(Blue).png").await?;
+        let whale_blue = load_texture(&format!(
+            "{}/assets/Whale/Whale(76x66)(Blue).png",
+            assets_dir
+        ))
+        .await?;
         whale_blue.set_filter(FilterMode::Nearest);
 
-        let whale_boots_green = load_texture("assets/Whale/WhaleBoots(76x66)(Green).png").await?;
+        let whale_boots_green = load_texture(&format!(
+            "{}/assets/Whale/WhaleBoots(76x66)(Green).png",
+            assets_dir
+        ))
+        .await?;
         whale_boots_green.set_filter(FilterMode::Nearest);
 
-        let whale_boots_blue = load_texture("assets/Whale/WhaleBoots(76x66)(Blue).png").await?;
+        let whale_boots_blue = load_texture(&format!(
+            "{}/assets/Whale/WhaleBoots(76x66)(Blue).png",
+            assets_dir
+        ))
+        .await?;
         whale_boots_blue.set_filter(FilterMode::Nearest);
 
-        let broken_turtleshell = load_texture("assets/Whale/BrokenTurtleShell(32x32).png").await?;
+        let broken_turtleshell = load_texture(&format!(
+            "{}/assets/Whale/BrokenTurtleShell(32x32).png",
+            assets_dir
+        ))
+        .await?;
         broken_turtleshell.set_filter(FilterMode::Nearest);
 
-        let turtleshell = load_texture("assets/Whale/TurtleShell(32x32).png").await?;
+        let turtleshell = load_texture(&format!(
+            "{}/assets/Whale/TurtleShell(32x32).png",
+            assets_dir
+        ))
+        .await?;
         turtleshell.set_filter(FilterMode::Nearest);
 
-        let background_01 = load_texture("assets/Background/01.png").await?;
+        let background_01 =
+            load_texture(&format!("{}/assets/Background/01.png", assets_dir)).await?;
         background_01.set_filter(FilterMode::Nearest);
 
-        let background_02 = load_texture("assets/Background/02.png").await?;
+        let background_02 =
+            load_texture(&format!("{}/assets/Background/02.png", assets_dir)).await?;
         background_02.set_filter(FilterMode::Nearest);
 
-        let background_03 = load_texture("assets/Background/03.png").await?;
+        let background_03 =
+            load_texture(&format!("{}/assets/Background/03.png", assets_dir)).await?;
         background_03.set_filter(FilterMode::Nearest);
 
-        let jump_sound = load_sound("assets/sounds/jump.wav").await?;
-        let shoot_sound = load_sound("assets/sounds/shoot.ogg").await?;
-        let sword_sound = load_sound("assets/sounds/sword.wav").await?;
-        let pickup_sound = load_sound("assets/sounds/pickup.wav").await?;
-        let player_landing_sound = load_sound("assets/sounds/player_landing.wav").await?;
-        let player_throw_sound = load_sound("assets/sounds/throw_noiz.wav").await?;
-        let player_die_sound = load_sound("assets/sounds/fish_fillet.wav").await?;
+        let jump_sound = load_sound(&format!("{}/assets/sounds/jump.wav", assets_dir)).await?;
+        let shoot_sound = load_sound(&format!("{}/assets/sounds/shoot.ogg", assets_dir)).await?;
+        let sword_sound = load_sound(&format!("{}/assets/sounds/sword.wav", assets_dir)).await?;
+        let pickup_sound = load_sound(&format!("{}/assets/sounds/pickup.wav", assets_dir)).await?;
+        let player_landing_sound =
+            load_sound(&format!("{}/assets/sounds/player_landing.wav", assets_dir)).await?;
+        let player_throw_sound =
+            load_sound(&format!("{}/assets/sounds/throw_noiz.wav", assets_dir)).await?;
+        let player_die_sound =
+            load_sound(&format!("{}/assets/sounds/fish_fillet.wav", assets_dir)).await?;
 
         let tiled_map_json = load_string(map).await.unwrap();
         let tiled_map = tiled::load_map(
@@ -153,7 +184,7 @@ impl Resources {
         let mut items_fxses = HashMap::new();
         for item in items::ITEMS {
             for (id, path) in item.textures {
-                let texture = load_texture(path).await?;
+                let texture = load_texture(&format!("{}/{}", assets_dir, path)).await?;
                 texture.set_filter(FilterMode::Nearest);
                 items_textures.insert(format!("{}/{}", item.tiled_name, id.to_string()), texture);
             }
@@ -202,13 +233,14 @@ impl Resources {
     }
 }
 
-async fn game(map: &str, game_type: GameType) {
+async fn game(map: &str, game_type: GameType, assets_dir: &str) {
     use nodes::{Camera, Decoration, Fxses, LevelBackground, LocalNetwork, Network, Player};
 
     let resources_loading = start_coroutine({
         let map = map.to_string();
+        let assets_dir = assets_dir.to_string();
         async move {
-            let resources = Resources::new(&map).await.unwrap();
+            let resources = Resources::new(&map, &assets_dir).await.unwrap();
             storage::store(resources);
         }
     });
@@ -230,11 +262,13 @@ async fn game(map: &str, game_type: GameType) {
     }
 
     let battle_music = if map == "assets/map.json" {
-        load_sound("assets/music/across the pond.ogg")
+        load_sound(&format!("{}/assets/music/across the pond.ogg", assets_dir))
             .await
             .unwrap()
     } else {
-        load_sound("assets/music/fish tide.ogg").await.unwrap()
+        load_sound(&format!("{}/assets/music/fish tide.ogg", assets_dir))
+            .await
+            .unwrap()
     };
 
     audio::play_sound(
@@ -328,8 +362,9 @@ fn window_conf() -> Conf {
 
 #[macroquad::main(window_conf)]
 async fn main() {
+    let assets_dir = env::var("FISHFIGHT_ASSETS").unwrap_or_else(|_| String::from("."));
     {
-        let gui_resources = gui::GuiResources::load().await;
+        let gui_resources = gui::GuiResources::load(&assets_dir).await;
         storage::store(gui_resources);
     }
 
@@ -343,7 +378,7 @@ async fn main() {
             GameType::Network { .. } => "assets/levels/lev01.json".to_string(),
         };
 
-        game(&map, game_type).await;
+        game(&map, game_type, &assets_dir).await;
 
         scene::clear();
     }


### PR DESCRIPTION
This PR makes it possible to specify the "assets/" directory at runtime by checking the presence of `FISHFIGHT_ASSETS` environment variable.

Closes #132
