### PR TITLE
Use dynamic asset location for the jellyfish asset

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,11 @@ impl Resources {
         .await?;
         turtleshell.set_filter(FilterMode::Nearest);
 
-        let flappy_jellyfish = load_texture("assets/Whale/FlappyJellyfish(34x47).png").await?;
+        let flappy_jellyfish = load_texture(&format!(
+            "{}/assets/Whale/FlappyJellyfish(34x47).png",
+            assets_dir
+        ))
+        .await?;
         flappy_jellyfish.set_filter(FilterMode::Nearest);
 
         let background_01 =


### PR DESCRIPTION
See #132

This PR updates the asset location for the Jellyfish implementation thus makes it specifiable at runtime with using `FISHFIGHT_ASSETS` environment variable.

