### PR TITLE
Add schema validation for JSON files

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.json"
+  pull_request:
+    paths:
+      - "**.json"
+
+name: Format validation check
+
+jobs:
+  json-validation:
+    runs-on: ubuntu-latest
+    name: Validate JSON files
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli
+
+      - name: Validate files
+        shell: bash
+        run: ./scripts/validate_json.sh

--- a/assets/items/cannon.schema.json
+++ b/assets/items/cannon.schema.json
@@ -1,0 +1,645 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#", 
+	"$id": "https://example.com/object1636323089.json", 
+	"title": "Root", 
+	"type": "object",
+	"required": [
+		"id",
+		"sprite",
+		"type",
+		"cooldown",
+		"recoil",
+		"uses",
+		"mount_offset",
+		"effect_offset",
+		"sound_effect",
+		"effects",
+		"collider_size",
+		"animation",
+		"effect_animation"
+	],
+	"properties": {
+		"id": {
+			"$id": "#root/id", 
+			"title": "Id", 
+			"type": "string",
+			"default": "",
+			"examples": [
+				"cannon"
+			],
+			"pattern": "^.*$"
+		},
+		"sprite": {
+			"$id": "#root/sprite", 
+			"title": "Sprite", 
+			"type": "object",
+			"required": [
+				"texture",
+				"offset"
+			],
+			"properties": {
+				"texture": {
+					"$id": "#root/sprite/texture", 
+					"title": "Texture", 
+					"type": "string",
+					"default": "",
+					"examples": [
+						"cannon"
+					],
+					"pattern": "^.*$"
+				},
+				"offset": {
+					"$id": "#root/sprite/offset", 
+					"title": "Offset", 
+					"type": "object",
+					"required": [
+						"x",
+						"y"
+					],
+					"properties": {
+						"x": {
+							"$id": "#root/sprite/offset/x", 
+							"title": "X", 
+							"type": "integer",
+							"examples": [
+								0
+							],
+							"default": 0
+						},
+						"y": {
+							"$id": "#root/sprite/offset/y", 
+							"title": "Y", 
+							"type": "integer",
+							"examples": [
+								-22
+							],
+							"default": 0
+						}
+					}
+				}
+
+			}
+		}
+,
+		"type": {
+			"$id": "#root/type", 
+			"title": "Type", 
+			"type": "string",
+			"default": "",
+			"examples": [
+				"weapon"
+			],
+			"pattern": "^.*$"
+		},
+		"cooldown": {
+			"$id": "#root/cooldown", 
+			"title": "Cooldown", 
+			"type": "number",
+			"examples": [
+				0.5
+			],
+			"default": 0.0
+		},
+		"recoil": {
+			"$id": "#root/recoil", 
+			"title": "Recoil", 
+			"type": "integer",
+			"examples": [
+				400
+			],
+			"default": 0
+		},
+		"uses": {
+			"$id": "#root/uses", 
+			"title": "Uses", 
+			"type": "integer",
+			"examples": [
+				3
+			],
+			"default": 0
+		},
+		"mount_offset": {
+			"$id": "#root/mount_offset", 
+			"title": "Mount_offset", 
+			"type": "object",
+			"required": [
+				"x",
+				"y"
+			],
+			"properties": {
+				"x": {
+					"$id": "#root/mount_offset/x", 
+					"title": "X", 
+					"type": "integer",
+					"examples": [
+						-16
+					],
+					"default": 0
+				},
+				"y": {
+					"$id": "#root/mount_offset/y", 
+					"title": "Y", 
+					"type": "integer",
+					"examples": [
+						-26
+					],
+					"default": 0
+				}
+			}
+		}
+,
+		"effect_offset": {
+			"$id": "#root/effect_offset", 
+			"title": "Effect_offset", 
+			"type": "object",
+			"required": [
+				"x",
+				"y"
+			],
+			"properties": {
+				"x": {
+					"$id": "#root/effect_offset/x", 
+					"title": "X", 
+					"type": "integer",
+					"examples": [
+						36
+					],
+					"default": 0
+				},
+				"y": {
+					"$id": "#root/effect_offset/y", 
+					"title": "Y", 
+					"type": "integer",
+					"examples": [
+						12
+					],
+					"default": 0
+				}
+			}
+		}
+,
+		"sound_effect": {
+			"$id": "#root/sound_effect", 
+			"title": "Sound_effect", 
+			"type": "string",
+			"default": "",
+			"examples": [
+				"shoot"
+			],
+			"pattern": "^.*$"
+		},
+		"effects": {
+			"$id": "#root/effects", 
+			"title": "Effects", 
+			"type": "object",
+			"required": [
+				"type",
+				"trigger",
+				"velocity",
+				"size",
+				"timed_trigger",
+				"effects",
+				"animation"
+			],
+			"properties": {
+				"type": {
+					"$id": "#root/effects/type", 
+					"title": "Type", 
+					"type": "string",
+					"default": "",
+					"examples": [
+						"triggered_effect"
+					],
+					"pattern": "^.*$"
+				},
+				"trigger": {
+					"$id": "#root/effects/trigger", 
+					"title": "Trigger", 
+					"type": "array",
+					"default": [],
+					"items":{
+						"$id": "#root/effects/trigger/items", 
+						"title": "Items", 
+						"type": "string",
+						"default": "",
+						"examples": [
+							"enemy"
+						],
+						"pattern": "^.*$"
+					}
+				},
+				"velocity": {
+					"$id": "#root/effects/velocity", 
+					"title": "Velocity", 
+					"type": "object",
+					"required": [
+						"x",
+						"y"
+					],
+					"properties": {
+						"x": {
+							"$id": "#root/effects/velocity/x", 
+							"title": "X", 
+							"type": "integer",
+							"examples": [
+								1000
+							],
+							"default": 0
+						},
+						"y": {
+							"$id": "#root/effects/velocity/y", 
+							"title": "Y", 
+							"type": "integer",
+							"examples": [
+								-50
+							],
+							"default": 0
+						}
+					}
+				}
+,
+				"size": {
+					"$id": "#root/effects/size", 
+					"title": "Size", 
+					"type": "object",
+					"required": [
+						"x",
+						"y"
+					],
+					"properties": {
+						"x": {
+							"$id": "#root/effects/size/x", 
+							"title": "X", 
+							"type": "integer",
+							"examples": [
+								17
+							],
+							"default": 0
+						},
+						"y": {
+							"$id": "#root/effects/size/y", 
+							"title": "Y", 
+							"type": "integer",
+							"examples": [
+								17
+							],
+							"default": 0
+						}
+					}
+				}
+,
+				"timed_trigger": {
+					"$id": "#root/effects/timed_trigger", 
+					"title": "Timed_trigger", 
+					"type": "number",
+					"examples": [
+						1.5
+					],
+					"default": 0.0
+				},
+				"effects": {
+					"$id": "#root/effects/effects", 
+					"title": "Effects", 
+					"type": "object",
+					"required": [
+						"type",
+						"radius",
+						"is_explosion",
+						"particle_effect",
+						"sound_effect"
+					],
+					"properties": {
+						"type": {
+							"$id": "#root/effects/effects/type", 
+							"title": "Type", 
+							"type": "string",
+							"default": "",
+							"examples": [
+								"circle_collider"
+							],
+							"pattern": "^.*$"
+						},
+						"radius": {
+							"$id": "#root/effects/effects/radius", 
+							"title": "Radius", 
+							"type": "integer",
+							"examples": [
+								64
+							],
+							"default": 0
+						},
+						"is_explosion": {
+							"$id": "#root/effects/effects/is_explosion", 
+							"title": "Is_explosion", 
+							"type": "boolean",
+							"examples": [
+								true
+							],
+							"default": true
+						},
+						"particle_effect": {
+							"$id": "#root/effects/effects/particle_effect", 
+							"title": "Particle_effect", 
+							"type": "string",
+							"default": "",
+							"examples": [
+								"hit"
+							],
+							"pattern": "^.*$"
+						},
+						"sound_effect": {
+							"$id": "#root/effects/effects/sound_effect", 
+							"title": "Sound_effect", 
+							"type": "string",
+							"default": "",
+							"examples": [
+								"explode"
+							],
+							"pattern": "^.*$"
+						}
+					}
+				}
+,
+				"animation": {
+					"$id": "#root/effects/animation", 
+					"title": "Animation", 
+					"type": "object",
+					"required": [
+						"texture",
+						"animations",
+						"should_autoplay"
+					],
+					"properties": {
+						"texture": {
+							"$id": "#root/effects/animation/texture", 
+							"title": "Texture", 
+							"type": "string",
+							"default": "",
+							"examples": [
+								"cannon_ball"
+							],
+							"pattern": "^.*$"
+						},
+						"animations": {
+							"$id": "#root/effects/animation/animations", 
+							"title": "Animations", 
+							"type": "array",
+							"default": [],
+							"items":{
+								"$id": "#root/effects/animation/animations/items", 
+								"title": "Items", 
+								"type": "object",
+								"required": [
+									"id",
+									"row",
+									"frames",
+									"fps"
+								],
+								"properties": {
+									"id": {
+										"$id": "#root/effects/animation/animations/items/id", 
+										"title": "Id", 
+										"type": "string",
+										"default": "",
+										"examples": [
+											"armed"
+										],
+										"pattern": "^.*$"
+									},
+									"row": {
+										"$id": "#root/effects/animation/animations/items/row", 
+										"title": "Row", 
+										"type": "integer",
+										"examples": [
+											0
+										],
+										"default": 0
+									},
+									"frames": {
+										"$id": "#root/effects/animation/animations/items/frames", 
+										"title": "Frames", 
+										"type": "integer",
+										"examples": [
+											1
+										],
+										"default": 0
+									},
+									"fps": {
+										"$id": "#root/effects/animation/animations/items/fps", 
+										"title": "Fps", 
+										"type": "integer",
+										"examples": [
+											1
+										],
+										"default": 0
+									}
+								}
+							}
+
+						},
+						"should_autoplay": {
+							"$id": "#root/effects/animation/should_autoplay", 
+							"title": "Should_autoplay", 
+							"type": "boolean",
+							"examples": [
+								true
+							],
+							"default": true
+						}
+					}
+				}
+
+			}
+		}
+,
+		"collider_size": {
+			"$id": "#root/collider_size", 
+			"title": "Collider_size", 
+			"type": "object",
+			"required": [
+				"x",
+				"y"
+			],
+			"properties": {
+				"x": {
+					"$id": "#root/collider_size/x", 
+					"title": "X", 
+					"type": "integer",
+					"examples": [
+						64
+					],
+					"default": 0
+				},
+				"y": {
+					"$id": "#root/collider_size/y", 
+					"title": "Y", 
+					"type": "integer",
+					"examples": [
+						24
+					],
+					"default": 0
+				}
+			}
+		}
+,
+		"animation": {
+			"$id": "#root/animation", 
+			"title": "Animation", 
+			"type": "object",
+			"required": [
+				"texture",
+				"animations"
+			],
+			"properties": {
+				"texture": {
+					"$id": "#root/animation/texture", 
+					"title": "Texture", 
+					"type": "string",
+					"default": "",
+					"examples": [
+						"cannon"
+					],
+					"pattern": "^.*$"
+				},
+				"animations": {
+					"$id": "#root/animation/animations", 
+					"title": "Animations", 
+					"type": "array",
+					"default": [],
+					"items":{
+						"$id": "#root/animation/animations/items", 
+						"title": "Items", 
+						"type": "object",
+						"required": [
+							"id",
+							"row",
+							"frames",
+							"fps"
+						],
+						"properties": {
+							"id": {
+								"$id": "#root/animation/animations/items/id", 
+								"title": "Id", 
+								"type": "string",
+								"default": "",
+								"examples": [
+									"idle"
+								],
+								"pattern": "^.*$"
+							},
+							"row": {
+								"$id": "#root/animation/animations/items/row", 
+								"title": "Row", 
+								"type": "integer",
+								"examples": [
+									0
+								],
+								"default": 0
+							},
+							"frames": {
+								"$id": "#root/animation/animations/items/frames", 
+								"title": "Frames", 
+								"type": "integer",
+								"examples": [
+									1
+								],
+								"default": 0
+							},
+							"fps": {
+								"$id": "#root/animation/animations/items/fps", 
+								"title": "Fps", 
+								"type": "integer",
+								"examples": [
+									1
+								],
+								"default": 0
+							}
+						}
+					}
+
+				}
+			}
+		}
+,
+		"effect_animation": {
+			"$id": "#root/effect_animation", 
+			"title": "Effect_animation", 
+			"type": "object",
+			"required": [
+				"texture",
+				"animations"
+			],
+			"properties": {
+				"texture": {
+					"$id": "#root/effect_animation/texture", 
+					"title": "Texture", 
+					"type": "string",
+					"default": "",
+					"examples": [
+						"cannon"
+					],
+					"pattern": "^.*$"
+				},
+				"animations": {
+					"$id": "#root/effect_animation/animations", 
+					"title": "Animations", 
+					"type": "array",
+					"default": [],
+					"items":{
+						"$id": "#root/effect_animation/animations/items", 
+						"title": "Items", 
+						"type": "object",
+						"required": [
+							"id",
+							"row",
+							"frames",
+							"fps"
+						],
+						"properties": {
+							"id": {
+								"$id": "#root/effect_animation/animations/items/id", 
+								"title": "Id", 
+								"type": "string",
+								"default": "",
+								"examples": [
+									"attack_effect"
+								],
+								"pattern": "^.*$"
+							},
+							"row": {
+								"$id": "#root/effect_animation/animations/items/row", 
+								"title": "Row", 
+								"type": "integer",
+								"examples": [
+									1
+								],
+								"default": 0
+							},
+							"frames": {
+								"$id": "#root/effect_animation/animations/items/frames", 
+								"title": "Frames", 
+								"type": "integer",
+								"examples": [
+									5
+								],
+								"default": 0
+							},
+							"fps": {
+								"$id": "#root/effect_animation/animations/items/fps", 
+								"title": "Fps", 
+								"type": "integer",
+								"examples": [
+									12
+								],
+								"default": 0
+							}
+						}
+					}
+
+				}
+			}
+		}
+
+	}
+}

--- a/assets/maps.schema.json
+++ b/assets/maps.schema.json
@@ -1,0 +1,47 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/object1636321057.json",
+  "title": "Root",
+  "type": "array",
+  "default": [],
+  "items": {
+    "$id": "#root/items",
+    "title": "Items",
+    "type": "object",
+    "required": ["name", "path", "preview_path", "is_tiled_map"],
+    "properties": {
+      "name": {
+        "$id": "#root/items/name",
+        "title": "Name",
+        "type": "string",
+        "default": "",
+        "examples": ["lev01"],
+        "pattern": "^.*$"
+      },
+      "path": {
+        "$id": "#root/items/path",
+        "title": "Path",
+        "type": "string",
+        "default": "",
+        "examples": ["maps/lev01.json"],
+        "pattern": "^.*$"
+      },
+      "preview_path": {
+        "$id": "#root/items/preview_path",
+        "title": "Preview_path",
+        "type": "string",
+        "default": "",
+        "examples": ["maps/lev01.png"],
+        "pattern": "^.*$"
+      },
+      "is_tiled_map": {
+        "$id": "#root/items/is_tiled_map",
+        "title": "Is_tiled_map",
+        "type": "boolean",
+        "examples": [true],
+        "default": true
+      }
+    }
+  }
+}

--- a/assets/textures.schema.json
+++ b/assets/textures.schema.json
@@ -1,0 +1,54 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/object1636321952.json",
+  "title": "Root",
+  "type": "array",
+  "default": [],
+  "items": {
+    "$id": "#root/items",
+    "title": "Items",
+    "type": "object",
+    "required": ["id", "path"],
+    "properties": {
+      "id": {
+        "$id": "#root/items/id",
+        "title": "Id",
+        "type": "string",
+        "default": "",
+        "examples": ["default_tool_icon"],
+        "pattern": "^.*$"
+      },
+      "path": {
+        "$id": "#root/items/path",
+        "title": "Path",
+        "type": "string",
+        "default": "",
+        "examples": ["textures/editor_icons/no_icon.png"],
+        "pattern": "^.*$"
+      },
+      "sprite_size": {
+        "$id": "#root/items/sprite_size",
+        "title": "Sprite_size",
+        "type": "object",
+        "required": ["x", "y"],
+        "properties": {
+          "x": {
+            "$id": "#root/items/sprite_size/x",
+            "title": "X",
+            "type": "integer",
+            "examples": [0],
+            "default": 0
+          },
+          "y": {
+            "$id": "#root/items/sprite_size/y",
+            "title": "Y",
+            "type": "integer",
+            "examples": [0],
+            "default": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_json.sh
+++ b/scripts/validate_json.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Validates the JSON files using JSON schemas (Draft-07).
+# https://json-schema.org/draft-07/json-schema-release-notes.html
+#
+# - "file.json" is being validated if "file.schema.json" is found.
+# - All of the JSON files in the same directory are being validated if "schema.json" is found.
+#
+# Required tool for validation: https://github.com/ajv-validator/ajv-cli/
+# Example JSON schema generator: https://extendsclass.com/json-schema-validator.html
+
+set -e
+
+find . -name "*schema.json" -print0 | while read -rd $'\0' schema
+do
+    echo "[~] Schema found: $schema"
+    if [[ $(basename "$schema") != "schema.json" ]]; then
+        ajv validate --spec=draft7 -s "$schema" -d "${schema//.schema/}"
+    else
+        find "$(dirname "$schema")" -maxdepth 1 \
+            -name "*.json" -not -name "*schema.json" -print0 |
+                xargs -0 -I {} ajv validate --spec=draft7 -s "$schema" -d {}
+    fi
+done


### PR DESCRIPTION
Closes #187

This PR adds the initial implementation for validating JSON files using schemas. There are a few key points:

- As mentioned in `validate_json.sh` script, schemas can be added and validated in 2 ways:
  - You can add the corresponding schema for a JSON file, such as `file.schema.json`
  - Or you add a _common_ schema file named `schema.json` in a directory and it is used for validating all of the JSON files in that directory.
- Current implementation only supports [JSON Draft-07 Schemas](https://json-schema.org/draft-07/json-schema-release-notes.html) and they can be written by hand or generated using tools like [this site](https://extendsclass.com/json-schema-validator.html).
- I only added 3 generated schema files in this PR but we should probably add more schema files for coverage. I can open an issue for tracking this when this PR is merged.
- You need [ajv-cli](https://github.com/ajv-validator/ajv-cli/) if you want to run the script on your local machine.
- `validation.yml` workflow only runs if a commit includes a change about any JSON file.

#### Workflow results

Successful run:

![success](https://user-images.githubusercontent.com/24392180/140665455-698a1b8f-3958-48a9-acfd-eb434aa1fed7.png)

Failed run:

![fail](https://user-images.githubusercontent.com/24392180/140665490-d5d07dff-e7d4-4589-89ab-61ecabd68826.png)

Also, you can see the workflow run for this PR here: https://github.com/fishfight/FishFight/runs/4133154596?check_suite_focus=true
