### PR TITLE
Map loading from editor menu

### DIFF
--- a/src/editor/gui/windows/background_properties.rs
+++ b/src/editor/gui/windows/background_properties.rs
@@ -7,7 +7,7 @@ use macroquad::{
 use crate::map::MapBackgroundLayer;
 use crate::{map::Map, Resources};
 
-use crate::gui::{GuiResources, ELEMENT_MARGIN};
+use crate::gui::{GuiResources, ELEMENT_MARGIN, LIST_BOX_ENTRY_HEIGHT};
 use crate::resources::TextureKind;
 
 use super::{ButtonParams, EditorAction, EditorContext, Window, WindowParams};
@@ -22,8 +22,6 @@ pub struct BackgroundPropertiesWindow {
 }
 
 impl BackgroundPropertiesWindow {
-    const LAYER_LIST_ENTRY_HEIGHT: f32 = 24.0;
-
     pub fn new(color: Color, layers: Vec<MapBackgroundLayer>) -> Self {
         let params = WindowParams {
             title: Some("Background Properties".to_string()),
@@ -127,7 +125,7 @@ impl Window for BackgroundPropertiesWindow {
             });
 
         let layer_list_size = vec2((size.x * 0.6) - ELEMENT_MARGIN, size.y * 0.5);
-        let layer_list_entry_size = vec2(layer_list_size.x, Self::LAYER_LIST_ENTRY_HEIGHT);
+        let layer_list_entry_size = vec2(layer_list_size.x, LIST_BOX_ENTRY_HEIGHT);
 
         {
             let gui_resources = storage::get::<GuiResources>();
@@ -140,7 +138,7 @@ impl Window for BackgroundPropertiesWindow {
                 let layers = self.layers.clone();
                 for (i, layer) in layers.iter().enumerate() {
                     widgets::Group::new(hash!(id, "layer_list_entry", i), layer_list_entry_size)
-                        .position(vec2(0.0, i as f32 * Self::LAYER_LIST_ENTRY_HEIGHT))
+                        .position(vec2(0.0, i as f32 * LIST_BOX_ENTRY_HEIGHT))
                         .ui(ui, |ui| {
                             let mut is_selected = false;
                             if let Some(index) = self.selected_layer {

--- a/src/editor/gui/windows/load_map.rs
+++ b/src/editor/gui/windows/load_map.rs
@@ -1,11 +1,7 @@
 use macroquad::{
     experimental::collections::storage,
-    ui::{
-        Ui,
-        hash,
-        widgets,
-    },
     prelude::*,
+    ui::{hash, widgets, Ui},
 };
 
 use crate::gui::{GuiResources, LIST_BOX_ENTRY_HEIGHT};

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -10,9 +10,8 @@ mod style;
 use macroquad::prelude::*;
 
 pub use style::{
-    SkinCollection, BUTTON_FONT_SIZE, BUTTON_MARGIN_H, BUTTON_MARGIN_V,
+    SkinCollection, BUTTON_FONT_SIZE, BUTTON_MARGIN_H, BUTTON_MARGIN_V, LIST_BOX_ENTRY_HEIGHT,
     SELECTED_OBJECT_HIGHLIGHT_COLOR, WINDOW_MARGIN_H, WINDOW_MARGIN_V,
-    LIST_BOX_ENTRY_HEIGHT,
 };
 
 pub use background::{draw_main_menu_background, Background};

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -12,6 +12,7 @@ use macroquad::prelude::*;
 pub use style::{
     SkinCollection, BUTTON_FONT_SIZE, BUTTON_MARGIN_H, BUTTON_MARGIN_V,
     SELECTED_OBJECT_HIGHLIGHT_COLOR, WINDOW_MARGIN_H, WINDOW_MARGIN_V,
+    LIST_BOX_ENTRY_HEIGHT,
 };
 
 pub use background::{draw_main_menu_background, Background};

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -27,6 +27,8 @@ pub const SELECTED_OBJECT_HIGHLIGHT_COLOR: Color = Color {
     a: 1.0,
 };
 
+pub const LIST_BOX_ENTRY_HEIGHT: f32 = 24.0;
+
 pub struct SkinCollection {
     pub default: Skin,
     pub button_disabled: Skin,


### PR DESCRIPTION
This enables loading of maps directly from the editor menu so you won't have to exit to main menu every time this is needed