### PR TITLE
Update ff-particles dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,12 +155,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff-particles"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a099eee8a45930a4a21516cf5a036df4bdff699641780eb5616192cba2afb12d"
+dependencies = [
+ "macroquad",
+ "serde",
+]
+
+[[package]]
 name = "fishfight"
 version = "0.2.0"
 dependencies = [
+ "ff-particles",
  "fishsticks",
  "macroquad",
- "macroquad-particles",
  "macroquad-platformer",
  "macroquad-profiler",
  "serde",
@@ -286,15 +296,6 @@ dependencies = [
  "miniquad",
  "quad-rand",
  "quad-snd",
-]
-
-[[package]]
-name = "macroquad-particles"
-version = "0.1.1"
-source = "git+https://github.com/olefasting/macroquad_particles#18f8528fbd77b723fe076744f295534181de5fd1"
-dependencies = [
- "macroquad",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ opt-level = 3
 macroquad = { version = "0.3.10" }
 macroquad-platformer = "0.1"
 macroquad-profiler = "0.1"
-macroquad-particles = { git = "https://github.com/olefasting/macroquad_particles", features = ["serde"] }
+
+ff-particles = { version = "0.1", features = ["serde"] }
 
 fishsticks = { git = "https://github.com/PotatoTech/fishsticks", features = ["bundled-sdl2"] }
 

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -9,7 +9,7 @@ use macroquad::{
     telemetry,
 };
 
-use macroquad_particles::EmittersCache;
+use ff_particles::EmittersCache;
 
 use crate::Resources;
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -6,7 +6,7 @@ use macroquad::{
     prelude::*,
 };
 
-use macroquad_particles::EmitterConfig;
+use ff_particles::EmitterConfig;
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
I renamed the `macroquad-particles` fork and published it on `crates.io` and this updates our dependencies accordingly