### PR TITLE
Projectile particle fix

### DIFF
--- a/src/components/animation_player.rs
+++ b/src/components/animation_player.rs
@@ -71,7 +71,7 @@ pub struct AnimationParams {
     #[serde(default)]
     pub should_autoplay: bool,
     /// If this is true, the `AnimationPlayer` will not be updated or drawn.
-    #[serde(default)]
+    #[serde(default, skip)]
     pub is_deactivated: bool,
 }
 

--- a/src/effects/active/projectiles.rs
+++ b/src/effects/active/projectiles.rs
@@ -100,7 +100,12 @@ impl Projectiles {
             }
         }
 
-        let particles = particles.into_iter().map(ParticleController::new).collect();
+        let mut particles = particles
+            .into_iter()
+            .map(ParticleController::new)
+            .collect::<Vec<ParticleController>>();
+
+        particles.iter_mut().for_each(|p| p.activate());
 
         self.active.push(Projectile {
             owner,

--- a/src/json/helpers.rs
+++ b/src/json/helpers.rs
@@ -235,3 +235,18 @@ impl GenericParamType for HashMap<String, GenericParam> {
         }
     }
 }
+
+pub trait BoolHelpers {
+    fn is_true(&self) -> bool;
+    fn is_false(&self) -> bool;
+}
+
+impl BoolHelpers for bool {
+    fn is_true(&self) -> bool {
+        *self
+    }
+
+    fn is_false(&self) -> bool {
+        !*self
+    }
+}

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,4 +1,4 @@
-mod helpers;
+pub mod helpers;
 mod map;
 mod math;
 mod render;


### PR DESCRIPTION
This adds `should_autostart` to `ParticleControllerParams` so that effects can be started automatically, once the controller is instantiated