### PR TITLE
Editor polishing

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -7,6 +7,16 @@ high-level overview of its API for those who are interested in contributing to i
 
 ![Screenshot of the Fish Fight editor. The map area and layers toolbar are visible. Default textures for platforms occupy the map area.](./assets/editor.png)
 
+## Keyboard shortcuts
+
+- `ctrl + S` save
+- `ctrl + shift + S` save as
+- `ctrl + L` load
+- `ctrl + Z` undo
+- `ctrl + shift + Z` redo
+- `G` toggle grid
+- `ctrl + G` toggle object snap to grid
+
 ## Accessing the editor
 
 The editor can be accessed from the "Editor" tab on the main menu. Selecting this item by clicking on it, or using the right arrow key on your keyboard (or if you're using a gamepad: the "right button"), will present two options: "Create Map" and "Load Map".

--- a/src/editor/camera.rs
+++ b/src/editor/camera.rs
@@ -36,6 +36,11 @@ impl EditorCamera {
         let rect = self.get_view_rect();
         position / self.scale + rect.point()
     }
+
+    pub fn to_screen_space(&self, position: Vec2) -> Vec2 {
+        let rect = self.get_view_rect();
+        (position - rect.point()) / self.scale
+    }
 }
 
 impl scene::Node for EditorCamera {

--- a/src/editor/input.rs
+++ b/src/editor/input.rs
@@ -4,90 +4,147 @@ use fishsticks::{Axis, Button};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum EditorInputScheme {
-    Keyboard,
+    Mouse,
     Gamepad(fishsticks::GamepadId),
 }
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct EditorInput {
     pub action: bool,
+    pub double_click: bool,
     pub back: bool,
     pub context_menu: bool,
     pub camera_pan: Vec2,
     pub camera_zoom: f32,
-    pub cursor_move: Vec2,
+    pub cursor_movement: Vec2,
     pub undo: bool,
     pub redo: bool,
     pub toggle_menu: bool,
+    pub toggle_grid: bool,
+
+    double_click_timer: f32,
 }
 
-pub fn collect_editor_input(scheme: EditorInputScheme) -> EditorInput {
-    let mut input = EditorInput::default();
+impl Default for EditorInput {
+    fn default() -> Self {
+        EditorInput {
+            action: false,
+            double_click: false,
+            back: false,
+            context_menu: false,
+            camera_pan: Vec2::ZERO,
+            camera_zoom: 0.0,
+            cursor_movement: Vec2::ZERO,
+            undo: false,
+            redo: false,
+            toggle_menu: false,
+            toggle_grid: false,
+            double_click_timer: Self::DOUBLE_CLICK_THRESHOLD,
+        }
+    }
+}
 
-    match scheme {
-        EditorInputScheme::Keyboard => {
-            input.action = is_mouse_button_down(MouseButton::Left);
-            input.back = is_mouse_button_down(MouseButton::Middle);
-            input.context_menu = is_mouse_button_pressed(MouseButton::Right);
+impl EditorInput {
+    const DOUBLE_CLICK_THRESHOLD: f32 = 0.25;
 
-            input.toggle_menu = is_key_pressed(KeyCode::Escape);
+    fn clear(&mut self) {
+        self.action = false;
+        self.double_click = false;
+        self.back = false;
+        self.context_menu = false;
+        self.camera_pan = Vec2::ZERO;
+        self.camera_zoom = 0.0;
+        self.cursor_movement = Vec2::ZERO;
+        self.undo = false;
+        self.redo = false;
+        self.toggle_menu = false;
+        self.toggle_grid = false;
+    }
 
-            if is_key_down(KeyCode::Left) || is_key_down(KeyCode::A) {
-                input.camera_pan.x = -1.0;
-            } else if is_key_down(KeyCode::Right) || is_key_down(KeyCode::D) {
-                input.camera_pan.x = 1.0;
+    pub fn update(&mut self, scheme: EditorInputScheme) {
+        let was_action = self.action || self.double_click;
+
+        self.clear();
+
+        match scheme {
+            EditorInputScheme::Mouse => {
+                if self.double_click_timer < Self::DOUBLE_CLICK_THRESHOLD {
+                    self.double_click_timer = (self.double_click_timer + get_frame_time())
+                        .clamp(0.0, Self::DOUBLE_CLICK_THRESHOLD);
+                }
+
+                if is_mouse_button_down(MouseButton::Left) {
+                    self.action = true;
+
+                    if !was_action && self.double_click_timer < Self::DOUBLE_CLICK_THRESHOLD {
+                        self.double_click = true;
+                    } else {
+                        self.double_click_timer = 0.0;
+                    }
+                }
+
+                self.back = is_mouse_button_down(MouseButton::Middle);
+                self.context_menu = is_mouse_button_pressed(MouseButton::Right);
+
+                self.toggle_menu = is_key_pressed(KeyCode::Escape);
+
+                if is_key_down(KeyCode::Left) || is_key_down(KeyCode::A) {
+                    self.camera_pan.x = -1.0;
+                } else if is_key_down(KeyCode::Right) || is_key_down(KeyCode::D) {
+                    self.camera_pan.x = 1.0;
+                }
+
+                if is_key_down(KeyCode::Up) || is_key_down(KeyCode::W) {
+                    self.camera_pan.y = -1.0;
+                } else if is_key_down(KeyCode::Down) || is_key_down(KeyCode::S) {
+                    self.camera_pan.y = 1.0;
+                }
+
+                let (_, zoom) = mouse_wheel();
+                if zoom < 0.0 {
+                    self.camera_zoom = -1.0;
+                } else if zoom > 0.0 {
+                    self.camera_zoom = 1.0;
+                }
+
+                if is_key_down(KeyCode::LeftControl) && is_key_pressed(KeyCode::Z) {
+                    if is_key_down(KeyCode::LeftShift) {
+                        self.redo = true;
+                    } else {
+                        self.undo = true;
+                    }
+                }
+
+                self.toggle_grid = is_key_pressed(KeyCode::G);
             }
+            EditorInputScheme::Gamepad(ix) => {
+                let gamepad_system = storage::get_mut::<fishsticks::GamepadContext>();
+                let gamepad = gamepad_system.gamepad(ix);
 
-            if is_key_down(KeyCode::Up) || is_key_down(KeyCode::W) {
-                input.camera_pan.y = -1.0;
-            } else if is_key_down(KeyCode::Down) || is_key_down(KeyCode::S) {
-                input.camera_pan.y = 1.0;
-            }
+                if let Some(gamepad) = gamepad {
+                    self.action = gamepad.digital_inputs.activated(Button::B);
+                    self.back = gamepad.digital_inputs.activated(Button::A);
+                    self.context_menu = gamepad.digital_inputs.activated(Button::X);
 
-            let (_, zoom) = mouse_wheel();
-            if zoom < 0.0 {
-                input.camera_zoom = -1.0;
-            } else if zoom > 0.0 {
-                input.camera_zoom = 1.0;
-            }
+                    self.camera_pan = {
+                        let direction_x = gamepad.analog_inputs.value(Axis::LeftX);
+                        let direction_y = gamepad.analog_inputs.value(Axis::LeftY);
 
-            if is_key_down(KeyCode::LeftControl) && is_key_pressed(KeyCode::Z) {
-                if is_key_down(KeyCode::LeftShift) {
-                    input.redo = true;
-                } else {
-                    input.undo = true;
+                        let direction = vec2(direction_x, direction_y);
+
+                        direction.normalize_or_zero()
+                    };
+
+                    self.cursor_movement = {
+                        let direction_x = gamepad.analog_inputs.value(Axis::RightX);
+                        let direction_y = gamepad.analog_inputs.value(Axis::RightY);
+
+                        let direction = vec2(direction_x, direction_y);
+
+                        direction.normalize_or_zero()
+                    };
                 }
             }
         }
-        EditorInputScheme::Gamepad(ix) => {
-            let gamepad_system = storage::get_mut::<fishsticks::GamepadContext>();
-            let gamepad = gamepad_system.gamepad(ix);
-
-            if let Some(gamepad) = gamepad {
-                input.action = gamepad.digital_inputs.activated(Button::B);
-                input.back = gamepad.digital_inputs.activated(Button::A);
-                input.context_menu = gamepad.digital_inputs.activated(Button::X);
-
-                input.camera_pan = {
-                    let direction_x = gamepad.analog_inputs.value(Axis::LeftX);
-                    let direction_y = gamepad.analog_inputs.value(Axis::LeftY);
-
-                    let direction = vec2(direction_x, direction_y);
-
-                    direction.normalize_or_zero()
-                };
-
-                input.cursor_move = {
-                    let direction_x = gamepad.analog_inputs.value(Axis::RightX);
-                    let direction_y = gamepad.analog_inputs.value(Axis::RightY);
-
-                    let direction = vec2(direction_x, direction_y);
-
-                    direction.normalize_or_zero()
-                };
-            }
-        }
     }
-
-    input
 }

--- a/src/editor/tools/eraser.rs
+++ b/src/editor/tools/eraser.rs
@@ -1,4 +1,4 @@
-use macroquad::prelude::*;
+use macroquad::{color, prelude::*};
 
 use super::{EditorAction, EditorContext, EditorTool, EditorToolParams};
 
@@ -46,6 +46,38 @@ impl EditorTool for EraserTool {
                 MapLayerKind::ObjectLayer => {
                     // TODO: Implement object layers
                 }
+            }
+        }
+
+        None
+    }
+
+    fn draw_cursor(&mut self, map: &Map, ctx: &EditorContext) -> Option<EditorAction> {
+        if let Some(layer_id) = &ctx.selected_layer {
+            let layer = map.layers.get(layer_id).unwrap();
+
+            if layer.kind == MapLayerKind::TileLayer {
+                let cursor_world_position= scene::find_node_by_type::<EditorCamera>()
+                    .unwrap()
+                    .to_world_space(ctx.cursor_position);
+
+                let coords = map.to_coords(cursor_world_position);
+                let position = map.to_position(coords);
+
+                let outline_color = if layer.tiles[map.to_index(coords)].is_some() {
+                    color::YELLOW
+                } else {
+                    color::RED
+                };
+
+                draw_rectangle_lines(
+                    position.x,
+                    position.y,
+                    map.tile_size.x,
+                    map.tile_size.y,
+                    2.0,
+                    outline_color,
+                );
             }
         }
 

--- a/src/editor/tools/eraser.rs
+++ b/src/editor/tools/eraser.rs
@@ -66,7 +66,7 @@ impl EditorTool for EraserTool {
             let layer = map.layers.get(layer_id).unwrap();
 
             if layer.kind == MapLayerKind::TileLayer {
-                let cursor_world_position= scene::find_node_by_type::<EditorCamera>()
+                let cursor_world_position = scene::find_node_by_type::<EditorCamera>()
                     .unwrap()
                     .to_world_space(ctx.cursor_position);
 

--- a/src/editor/tools/eraser.rs
+++ b/src/editor/tools/eraser.rs
@@ -52,6 +52,15 @@ impl EditorTool for EraserTool {
         None
     }
 
+    fn is_available(&self, map: &Map, ctx: &EditorContext) -> bool {
+        if let Some(layer_id) = &ctx.selected_layer {
+            let layer = map.layers.get(layer_id).unwrap();
+            return layer.kind == MapLayerKind::TileLayer;
+        }
+
+        false
+    }
+
     fn draw_cursor(&mut self, map: &Map, ctx: &EditorContext) -> Option<EditorAction> {
         if let Some(layer_id) = &ctx.selected_layer {
             let layer = map.layers.get(layer_id).unwrap();

--- a/src/editor/tools/mod.rs
+++ b/src/editor/tools/mod.rs
@@ -75,4 +75,8 @@ pub trait EditorTool {
     fn is_available(&self, _map: &Map, _ctx: &EditorContext) -> bool {
         true
     }
+
+    fn draw_cursor(&mut self, _map: &Map, _ctx: &EditorContext) -> Option<EditorAction> {
+        None
+    }
 }

--- a/src/editor/tools/mod.rs
+++ b/src/editor/tools/mod.rs
@@ -4,7 +4,7 @@ mod eraser;
 mod placement;
 
 pub use eraser::EraserTool;
-pub use placement::{ObjectPlacementTool, TilePlacementTool};
+pub use placement::TilePlacementTool;
 
 use macroquad::prelude::*;
 

--- a/src/editor/tools/placement.rs
+++ b/src/editor/tools/placement.rs
@@ -1,11 +1,12 @@
-use macroquad::prelude::*;
+use macroquad::{
+    experimental::collections::storage,
+    color,
+    prelude::*,
+};
 
 use super::{EditorAction, EditorContext, EditorTool, EditorToolParams};
 
-use crate::{
-    editor::EditorCamera,
-    map::{Map, MapLayerKind},
-};
+use crate::{editor::EditorCamera, map::{Map, MapLayerKind}, Resources};
 
 #[derive(Default)]
 pub struct TilePlacementTool {
@@ -57,6 +58,54 @@ impl EditorTool for TilePlacementTool {
         }
 
         false
+    }
+
+    fn draw_cursor(&mut self, map: &Map, ctx: &EditorContext) -> Option<EditorAction> {
+        if let Some(layer_id) = &ctx.selected_layer {
+            let layer = map.layers.get(layer_id).unwrap();
+
+            if layer.kind == MapLayerKind::TileLayer {
+                if let Some(tileset_id) = &ctx.selected_tileset {
+                    if let Some(tile_id) = ctx.selected_tile {
+                        let tileset = map.tilesets.get(tileset_id).unwrap();
+
+                        let cursor_world_position = scene::find_node_by_type::<EditorCamera>()
+                            .unwrap()
+                            .to_world_space(ctx.cursor_position);
+
+                        let coords = map.to_coords(cursor_world_position);
+                        let position = map.to_position(coords);
+
+                        let texture_coords = tileset.get_texture_coords(tile_id);
+                        let texture = {
+                            let resources = storage::get::<Resources>();
+                            let res = resources.textures.get(&tileset.texture_id).unwrap();
+                            res.texture
+                        };
+
+                        let source_rect = Rect::new(
+                            texture_coords.x,
+                            texture_coords.y,
+                            map.tile_size.x,
+                            map.tile_size.y);
+
+                        draw_texture_ex(
+                            texture,
+                            position.x,
+                            position.y,
+                            color::WHITE,
+                            DrawTextureParams {
+                                dest_size: Some(map.tile_size),
+                                source: Some(source_rect),
+                                ..Default::default()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        None
     }
 }
 

--- a/src/editor/tools/placement.rs
+++ b/src/editor/tools/placement.rs
@@ -109,6 +109,7 @@ impl EditorTool for TilePlacementTool {
     }
 }
 
+/*
 #[derive(Default)]
 pub struct ObjectPlacementTool {
     params: EditorToolParams,
@@ -151,3 +152,4 @@ impl EditorTool for ObjectPlacementTool {
         false
     }
 }
+*/

--- a/src/editor/tools/placement.rs
+++ b/src/editor/tools/placement.rs
@@ -1,12 +1,12 @@
-use macroquad::{
-    experimental::collections::storage,
-    color,
-    prelude::*,
-};
+use macroquad::{color, experimental::collections::storage, prelude::*};
 
 use super::{EditorAction, EditorContext, EditorTool, EditorToolParams};
 
-use crate::{editor::EditorCamera, map::{Map, MapLayerKind}, Resources};
+use crate::{
+    editor::EditorCamera,
+    map::{Map, MapLayerKind},
+    Resources,
+};
 
 #[derive(Default)]
 pub struct TilePlacementTool {
@@ -87,7 +87,8 @@ impl EditorTool for TilePlacementTool {
                             texture_coords.x,
                             texture_coords.y,
                             map.tile_size.x,
-                            map.tile_size.y);
+                            map.tile_size.y,
+                        );
 
                         draw_texture_ex(
                             texture,
@@ -98,7 +99,7 @@ impl EditorTool for TilePlacementTool {
                                 dest_size: Some(map.tile_size),
                                 source: Some(source_rect),
                                 ..Default::default()
-                            }
+                            },
                         )
                     }
                 }

--- a/src/gui/main_menu.rs
+++ b/src/gui/main_menu.rs
@@ -174,13 +174,13 @@ pub async fn show_main_menu() -> MainMenuResult {
                     match res.into_usize() {
                         EDITOR_OPTION_CREATE => {
                             return MainMenuResult::Editor {
-                                input_scheme: EditorInputScheme::Keyboard,
+                                input_scheme: EditorInputScheme::Mouse,
                                 is_new_map: true,
                             }
                         }
                         EDITOR_OPTION_LOAD => {
                             return MainMenuResult::Editor {
-                                input_scheme: EditorInputScheme::Keyboard,
+                                input_scheme: EditorInputScheme::Mouse,
                                 is_new_map: false,
                             }
                         }


### PR DESCRIPTION
This adds the following to the editor:

- Map bounds and tile grid can be toggled by pressing `G`
- Double clicking an object will now open its properties
- Selected objects can be moved by drag and drop
- Grid snap when moving objects by dragging can be toggled by pressing `ctrl + G`
- Save map by pressing `ctrl + S`, save as by pressing `ctrl + shift + S` and load map by pressing `ctrl + L`