### PR TITLE
Tile attributes

### DIFF
--- a/src/editor/gui/toolbars/layer_list.rs
+++ b/src/editor/gui/toolbars/layer_list.rs
@@ -88,22 +88,19 @@ impl ToolbarElement for LayerListElement {
 
             {
                 let btn_size = vec2(50.0, entry_size.y);
-                let btn_position = vec2(position.x + entry_size.x - btn_size.x - ELEMENT_MARGIN, position.y);
+                let btn_position = vec2(
+                    position.x + entry_size.x - btn_size.x - ELEMENT_MARGIN,
+                    position.y,
+                );
 
-                let label = if layer.is_visible {
-                    "[hide]"
-                } else {
-                    "[show]"
-                };
+                let label = if layer.is_visible { "[hide]" } else { "[show]" };
 
                 let visibility_btn = widgets::Button::new("")
                     .size(btn_size)
                     .position(btn_position)
                     .ui(ui);
 
-                widgets::Label::new(label)
-                    .position(btn_position)
-                    .ui(ui);
+                widgets::Label::new(label).position(btn_position).ui(ui);
 
                 if visibility_btn {
                     let action = EditorAction::UpdateLayer {

--- a/src/editor/gui/toolbars/layer_list.rs
+++ b/src/editor/gui/toolbars/layer_list.rs
@@ -63,29 +63,59 @@ impl ToolbarElement for LayerListElement {
                 ui.push_skin(&gui_resources.skins.list_box_selected);
             }
 
-            let button = widgets::Button::new("")
+            let layer_btn = widgets::Button::new("")
                 .size(entry_size)
                 .position(position)
                 .ui(ui);
 
-            ui.label(position, layer_id);
+            let label = if layer.kind == MapLayerKind::ObjectLayer {
+                format!("(O) {}", layer_id)
+            } else {
+                format!("(T) {}", layer_id)
+            };
 
-            if layer.kind == MapLayerKind::ObjectLayer {
-                let suffix = "(Obj)";
+            ui.label(position, &label);
 
-                let suffix_size = ui.calc_size(suffix);
-                let position = vec2(size.x - suffix_size.x - ELEMENT_MARGIN, position.y);
-
-                ui.label(position, suffix);
-            }
-
-            if button {
+            if layer_btn {
                 res = Some(EditorAction::SelectLayer(layer_id.clone()));
             }
 
             if is_selected {
                 ui.pop_skin();
             }
+
+            ui.push_skin(&gui_resources.skins.list_box_no_bg);
+
+            {
+                let btn_size = vec2(50.0, entry_size.y);
+                let btn_position = vec2(position.x + entry_size.x - btn_size.x - ELEMENT_MARGIN, position.y);
+
+                let label = if layer.is_visible {
+                    "[hide]"
+                } else {
+                    "[show]"
+                };
+
+                let visibility_btn = widgets::Button::new("")
+                    .size(btn_size)
+                    .position(btn_position)
+                    .ui(ui);
+
+                widgets::Label::new(label)
+                    .position(btn_position)
+                    .ui(ui);
+
+                if visibility_btn {
+                    let action = EditorAction::UpdateLayer {
+                        id: layer_id.clone(),
+                        is_visible: !layer.is_visible,
+                    };
+
+                    res = Some(action);
+                }
+            }
+
+            ui.pop_skin();
 
             position.y += entry_size.y;
         }

--- a/src/editor/gui/windows/mod.rs
+++ b/src/editor/gui/windows/mod.rs
@@ -13,6 +13,7 @@ mod import;
 mod load_map;
 mod object_properties;
 mod save_map;
+mod tile_properties;
 mod tileset_properties;
 
 pub use background_properties::BackgroundPropertiesWindow;
@@ -25,6 +26,7 @@ pub use import::ImportWindow;
 pub use load_map::LoadMapWindow;
 pub use object_properties::ObjectPropertiesWindow;
 pub use save_map::SaveMapWindow;
+pub use tile_properties::TilePropertiesWindow;
 pub use tileset_properties::TilesetPropertiesWindow;
 
 use super::{ButtonParams, EditorAction, EditorContext, Map};

--- a/src/editor/gui/windows/tile_properties.rs
+++ b/src/editor/gui/windows/tile_properties.rs
@@ -1,0 +1,110 @@
+use macroquad::{
+    prelude::*,
+    ui::{hash, Ui},
+};
+
+use crate::map::Map;
+
+use crate::gui::Checkbox;
+
+use super::{ButtonParams, EditorAction, EditorContext, Window, WindowParams};
+
+const JUMPTHROUGH_ATTRIBUTE: &str = "jumpthrough";
+
+pub struct TilePropertiesWindow {
+    params: WindowParams,
+    layer_id: String,
+    index: usize,
+    attributes: Option<Vec<String>>,
+}
+
+impl TilePropertiesWindow {
+    pub fn new(layer_id: String, index: usize) -> Self {
+        let params = WindowParams {
+            title: Some("Tile Properties".to_string()),
+            size: vec2(300.0, 200.0),
+            ..Default::default()
+        };
+
+        TilePropertiesWindow {
+            params,
+            layer_id,
+            index,
+            attributes: None,
+        }
+    }
+}
+
+impl Window for TilePropertiesWindow {
+    fn get_params(&self) -> &WindowParams {
+        &self.params
+    }
+
+    fn get_buttons(&self, _map: &Map, _ctx: &EditorContext) -> Vec<ButtonParams> {
+        let mut res = Vec::new();
+
+        let mut action = None;
+
+        if let Some(attributes) = self.attributes.clone() {
+            let batch = self
+                .get_close_action()
+                .then(EditorAction::UpdateTileAttributes {
+                    layer_id: self.layer_id.clone(),
+                    index: self.index,
+                    attributes,
+                });
+
+            action = Some(batch);
+        }
+
+        res.push(ButtonParams {
+            label: "Save",
+            action,
+            ..Default::default()
+        });
+
+        res.push(ButtonParams {
+            label: "Cancel",
+            action: Some(self.get_close_action()),
+            ..Default::default()
+        });
+
+        res
+    }
+
+    fn draw(
+        &mut self,
+        ui: &mut Ui,
+        _size: Vec2,
+        map: &Map,
+        _ctx: &EditorContext,
+    ) -> Option<EditorAction> {
+        let id = hash!("update_tile_window");
+
+        if self.attributes.is_none() {
+            if let Some(layer) = map.layers.get(&self.layer_id) {
+                if let Some(Some(tile)) = layer.tiles.get(self.index) {
+                    self.attributes = Some(tile.attributes.clone());
+                }
+            }
+        }
+
+        let mut is_jumpthrough;
+
+        if let Some(attributes) = &mut self.attributes {
+            let was_jumpthrough = attributes.contains(&(JUMPTHROUGH_ATTRIBUTE.to_string()));
+            is_jumpthrough = was_jumpthrough;
+
+            Checkbox::new(hash!(id, "jumpthrough_input"), None, "Platform")
+                .ui(ui, &mut is_jumpthrough);
+
+            if is_jumpthrough && !was_jumpthrough {
+                attributes.push(JUMPTHROUGH_ATTRIBUTE.to_string());
+            } else if !is_jumpthrough && was_jumpthrough {
+                attributes.retain(|s| s != JUMPTHROUGH_ATTRIBUTE);
+            }
+        }
+
+        None
+    }
+}

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -39,7 +39,7 @@ pub use tools::{
 use history::EditorHistory;
 pub use input::EditorInputScheme;
 
-use crate::editor::actions::{ImportAction, UpdateBackgroundAction, UpdateObjectAction};
+use crate::editor::actions::{ImportAction, UpdateBackgroundAction, UpdateLayerAction, UpdateObjectAction};
 use crate::editor::gui::windows::{
     BackgroundPropertiesWindow, CreateMapWindow, ImportWindow, LoadMapWindow,
     ObjectPropertiesWindow, SaveMapWindow,
@@ -424,6 +424,13 @@ impl Editor {
                 res = self
                     .history
                     .apply(Box::new(action), &mut self.map_resource.map);
+            }
+            EditorAction::UpdateLayer {
+                id,
+                is_visible,
+            } => {
+                let action = UpdateLayerAction::new(id, is_visible);
+                res = self.history.apply(Box::new(action), &mut self.map_resource.map);
             }
             EditorAction::SelectTileset(id) => {
                 self.select_tileset(&id, None);
@@ -990,145 +997,102 @@ impl Node for Editor {
             let resources = storage::get::<Resources>();
 
             for layer in node.get_map().layers.values() {
-                if layer.kind == MapLayerKind::ObjectLayer {
-                    for (i, object) in layer.objects.iter().enumerate() {
-                        let mut label = None;
+                if layer.is_visible {
+                    if layer.kind == MapLayerKind::ObjectLayer {
+                        for (i, object) in layer.objects.iter().enumerate() {
+                            let mut label = None;
 
-                        let mut is_selected = false;
-                        if let Some(layer_id) = &node.selected_layer {
-                            if let Some(index) = node.selected_object {
-                                is_selected = *layer_id == layer.id && index == i;
-                            }
-                        }
-
-                        let mut object_position =
-                            node.map_resource.map.world_offset + object.position;
-
-                        if let Some(dragged_object) = &node.dragged_object {
-                            if layer.id == dragged_object.layer_id && dragged_object.index == i {
-                                let map = node.get_map();
-
-                                let cursor_world_position =
-                                    scene::find_node_by_type::<EditorCamera>()
-                                        .unwrap()
-                                        .to_world_space(
-                                            node.cursor_position - dragged_object.click_offset,
-                                        );
-
-                                object_position = (cursor_world_position).clamp(
-                                    map.world_offset,
-                                    map.world_offset + (map.grid_size.as_f32() * map.tile_size),
-                                );
-
-                                if node.should_snap_to_grid {
-                                    let coords = map.to_coords(object_position);
-                                    object_position = map.to_position(coords);
+                            let mut is_selected = false;
+                            if let Some(layer_id) = &node.selected_layer {
+                                if let Some(index) = node.selected_object {
+                                    is_selected = *layer_id == layer.id && index == i;
                                 }
                             }
-                        }
 
-                        match object.kind {
-                            MapObjectKind::Item => {
-                                if let Some(params) = resources.items.get(&object.id) {
-                                    if let Some(texture_res) =
-                                        resources.textures.get(&params.sprite.texture_id)
-                                    {
-                                        let position = object_position + params.sprite.offset;
+                            let mut object_position =
+                                node.map_resource.map.world_offset + object.position;
 
-                                        let frame_size = texture_res
-                                            .meta
-                                            .sprite_size
-                                            .map(|v| v.as_f32())
-                                            .unwrap_or_else(|| {
-                                                vec2(
-                                                    texture_res.texture.width(),
-                                                    texture_res.texture.height(),
-                                                )
-                                            });
+                            if let Some(dragged_object) = &node.dragged_object {
+                                if layer.id == dragged_object.layer_id && dragged_object.index == i {
+                                    let map = node.get_map();
 
-                                        let source_rect = {
-                                            let grid_size = vec2(
-                                                texture_res.texture.width() / frame_size.x,
-                                                texture_res.texture.height() / frame_size.y,
-                                            )
-                                            .as_u32();
+                                    let cursor_world_position =
+                                        scene::find_node_by_type::<EditorCamera>()
+                                            .unwrap()
+                                            .to_world_space(
+                                                node.cursor_position - dragged_object.click_offset,
+                                            );
 
-                                            let i = params.sprite.index as u32;
-                                            let coords = uvec2(i % grid_size.y, i / grid_size.y);
-
-                                            Rect::new(
-                                                coords.x as f32 * frame_size.x,
-                                                coords.y as f32 * frame_size.y,
-                                                frame_size.x,
-                                                frame_size.y,
-                                            )
-                                        };
-
-                                        draw_texture_ex(
-                                            texture_res.texture,
-                                            position.x,
-                                            position.y,
-                                            color::WHITE,
-                                            DrawTextureParams {
-                                                dest_size: Some(frame_size),
-                                                source: Some(source_rect),
-                                                ..Default::default()
-                                            },
-                                        );
-                                    } else {
-                                        label = Some("INVALID TEXTURE ID".to_string());
-                                    }
-                                } else {
-                                    label = Some("INVALID OBJECT ID".to_string());
-                                }
-                            }
-                            MapObjectKind::Decoration => {
-                                let texture_res =
-                                    resources.textures.get("default_decorations").unwrap();
-
-                                let frame_size = texture_res
-                                    .meta
-                                    .sprite_size
-                                    .map(|v| v.as_f32())
-                                    .unwrap_or_else(|| {
-                                        vec2(
-                                            texture_res.texture.width(),
-                                            texture_res.texture.height(),
-                                        )
-                                    });
-
-                                let mut source_rect = None;
-                                if &object.id == "pot" {
-                                    source_rect = Some(Rect::new(
-                                        0.0,
-                                        frame_size.y,
-                                        frame_size.x,
-                                        frame_size.y,
-                                    ));
-                                } else if &object.id == "seaweed" {
-                                    source_rect =
-                                        Some(Rect::new(0.0, 0.0, frame_size.x, frame_size.y));
-                                }
-
-                                if source_rect.is_some() {
-                                    draw_texture_ex(
-                                        texture_res.texture,
-                                        object_position.x,
-                                        object_position.y,
-                                        color::WHITE,
-                                        DrawTextureParams {
-                                            dest_size: Some(frame_size),
-                                            source: source_rect,
-                                            ..Default::default()
-                                        },
+                                    object_position = (cursor_world_position).clamp(
+                                        map.world_offset,
+                                        map.world_offset + (map.grid_size.as_f32() * map.tile_size),
                                     );
-                                } else {
-                                    label = Some("INVALID OBJECT ID".to_string());
+
+                                    if node.should_snap_to_grid {
+                                        let coords = map.to_coords(object_position);
+                                        object_position = map.to_position(coords);
+                                    }
                                 }
                             }
-                            MapObjectKind::Environment => {
-                                if &object.id == "sproinger" {
-                                    let texture_res = resources.textures.get("sproinger").unwrap();
+
+                            match object.kind {
+                                MapObjectKind::Item => {
+                                    if let Some(params) = resources.items.get(&object.id) {
+                                        if let Some(texture_res) =
+                                        resources.textures.get(&params.sprite.texture_id)
+                                        {
+                                            let position = object_position + params.sprite.offset;
+
+                                            let frame_size = texture_res
+                                                .meta
+                                                .sprite_size
+                                                .map(|v| v.as_f32())
+                                                .unwrap_or_else(|| {
+                                                    vec2(
+                                                        texture_res.texture.width(),
+                                                        texture_res.texture.height(),
+                                                    )
+                                                });
+
+                                            let source_rect = {
+                                                let grid_size = vec2(
+                                                    texture_res.texture.width() / frame_size.x,
+                                                    texture_res.texture.height() / frame_size.y,
+                                                )
+                                                    .as_u32();
+
+                                                let i = params.sprite.index as u32;
+                                                let coords = uvec2(i % grid_size.y, i / grid_size.y);
+
+                                                Rect::new(
+                                                    coords.x as f32 * frame_size.x,
+                                                    coords.y as f32 * frame_size.y,
+                                                    frame_size.x,
+                                                    frame_size.y,
+                                                )
+                                            };
+
+                                            draw_texture_ex(
+                                                texture_res.texture,
+                                                position.x,
+                                                position.y,
+                                                color::WHITE,
+                                                DrawTextureParams {
+                                                    dest_size: Some(frame_size),
+                                                    source: Some(source_rect),
+                                                    ..Default::default()
+                                                },
+                                            );
+                                        } else {
+                                            label = Some("INVALID TEXTURE ID".to_string());
+                                        }
+                                    } else {
+                                        label = Some("INVALID OBJECT ID".to_string());
+                                    }
+                                }
+                                MapObjectKind::Decoration => {
+                                    let texture_res =
+                                        resources.textures.get("default_decorations").unwrap();
 
                                     let frame_size = texture_res
                                         .meta
@@ -1141,52 +1105,97 @@ impl Node for Editor {
                                             )
                                         });
 
-                                    let source_rect =
-                                        Rect::new(0.0, 0.0, frame_size.x, frame_size.y);
+                                    let mut source_rect = None;
+                                    if &object.id == "pot" {
+                                        source_rect = Some(Rect::new(
+                                            0.0,
+                                            frame_size.y,
+                                            frame_size.x,
+                                            frame_size.y,
+                                        ));
+                                    } else if &object.id == "seaweed" {
+                                        source_rect =
+                                            Some(Rect::new(0.0, 0.0, frame_size.x, frame_size.y));
+                                    }
 
-                                    draw_texture_ex(
-                                        texture_res.texture,
-                                        object_position.x,
-                                        object_position.y,
-                                        color::WHITE,
-                                        DrawTextureParams {
-                                            dest_size: Some(frame_size),
-                                            source: Some(source_rect),
-                                            ..Default::default()
-                                        },
-                                    );
-                                } else {
-                                    label = Some("INVALID OBJECT ID".to_string());
+                                    if source_rect.is_some() {
+                                        draw_texture_ex(
+                                            texture_res.texture,
+                                            object_position.x,
+                                            object_position.y,
+                                            color::WHITE,
+                                            DrawTextureParams {
+                                                dest_size: Some(frame_size),
+                                                source: source_rect,
+                                                ..Default::default()
+                                            },
+                                        );
+                                    } else {
+                                        label = Some("INVALID OBJECT ID".to_string());
+                                    }
+                                }
+                                MapObjectKind::Environment => {
+                                    if &object.id == "sproinger" {
+                                        let texture_res = resources.textures.get("sproinger").unwrap();
+
+                                        let frame_size = texture_res
+                                            .meta
+                                            .sprite_size
+                                            .map(|v| v.as_f32())
+                                            .unwrap_or_else(|| {
+                                                vec2(
+                                                    texture_res.texture.width(),
+                                                    texture_res.texture.height(),
+                                                )
+                                            });
+
+                                        let source_rect =
+                                            Rect::new(0.0, 0.0, frame_size.x, frame_size.y);
+
+                                        draw_texture_ex(
+                                            texture_res.texture,
+                                            object_position.x,
+                                            object_position.y,
+                                            color::WHITE,
+                                            DrawTextureParams {
+                                                dest_size: Some(frame_size),
+                                                source: Some(source_rect),
+                                                ..Default::default()
+                                            },
+                                        );
+                                    } else {
+                                        label = Some("INVALID OBJECT ID".to_string());
+                                    }
+                                }
+                                MapObjectKind::SpawnPoint => {
+                                    label = Some("Spawn Point".to_string());
                                 }
                             }
-                            MapObjectKind::SpawnPoint => {
-                                label = Some("Spawn Point".to_string());
+
+                            let size = get_object_size(object);
+
+                            if let Some(label) = &label {
+                                let params = TextParams::default();
+
+                                draw_text_ex(
+                                    label,
+                                    object_position.x,
+                                    object_position.y + (size.y / 2.0)
+                                        - Self::OBJECT_SELECTION_RECT_PADDING,
+                                    params,
+                                );
                             }
-                        }
 
-                        let size = get_object_size(object);
-
-                        if let Some(label) = &label {
-                            let params = TextParams::default();
-
-                            draw_text_ex(
-                                label,
-                                object_position.x,
-                                object_position.y + (size.y / 2.0)
-                                    - Self::OBJECT_SELECTION_RECT_PADDING,
-                                params,
-                            );
-                        }
-
-                        if is_selected {
-                            draw_rectangle_lines(
-                                object_position.x - Self::OBJECT_SELECTION_RECT_PADDING,
-                                object_position.y - Self::OBJECT_SELECTION_RECT_PADDING,
-                                size.x,
-                                size.y,
-                                4.0,
-                                SELECTED_OBJECT_HIGHLIGHT_COLOR,
-                            );
+                            if is_selected {
+                                draw_rectangle_lines(
+                                    object_position.x - Self::OBJECT_SELECTION_RECT_PADDING,
+                                    object_position.y - Self::OBJECT_SELECTION_RECT_PADDING,
+                                    size.x,
+                                    size.y,
+                                    4.0,
+                                    SELECTED_OBJECT_HIGHLIGHT_COLOR,
+                                );
+                            }
                         }
                     }
                 }

--- a/src/game/scene.rs
+++ b/src/game/scene.rs
@@ -48,8 +48,10 @@ pub fn create_game_scene(
     // Objects are cloned since Item constructor requires `GameWorld` in storage
     let mut map_objects = Vec::new();
     for layer in map.layers.values() {
-        if layer.kind == MapLayerKind::ObjectLayer {
-            map_objects.append(&mut layer.objects.clone());
+        if layer.is_visible {
+            if layer.kind == MapLayerKind::ObjectLayer {
+                map_objects.append(&mut layer.objects.clone());
+            }
         }
     }
 

--- a/src/game/scene.rs
+++ b/src/game/scene.rs
@@ -48,10 +48,8 @@ pub fn create_game_scene(
     // Objects are cloned since Item constructor requires `GameWorld` in storage
     let mut map_objects = Vec::new();
     for layer in map.layers.values() {
-        if layer.is_visible {
-            if layer.kind == MapLayerKind::ObjectLayer {
-                map_objects.append(&mut layer.objects.clone());
-            }
+        if layer.is_visible && layer.kind == MapLayerKind::ObjectLayer {
+            map_objects.append(&mut layer.objects.clone());
         }
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -13,7 +13,7 @@ use macroquad::prelude::*;
 
 pub use style::{
     SkinCollection, BUTTON_FONT_SIZE, BUTTON_MARGIN_H, BUTTON_MARGIN_V, LIST_BOX_ENTRY_HEIGHT,
-    SELECTED_OBJECT_HIGHLIGHT_COLOR, WINDOW_BG_COLOR, WINDOW_MARGIN_H, WINDOW_MARGIN_V,
+    SELECTION_HIGHLIGHT_COLOR, WINDOW_BG_COLOR, WINDOW_MARGIN_H, WINDOW_MARGIN_V,
 };
 
 pub use background::{draw_main_menu_background, Background};

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -67,7 +67,7 @@ pub const WINDOW_BG_COLOR: Color = Color {
     a: 1.0,
 };
 
-pub const SELECTED_OBJECT_HIGHLIGHT_COLOR: Color = Color {
+pub const SELECTION_HIGHLIGHT_COLOR: Color = Color {
     r: 0.23,
     g: 0.67,
     b: 0.41,


### PR DESCRIPTION
This adds tile selection and a tile attributes window, accessible by double clicking a tile.

It will only give you the possibility to set a tile as jumpthrough, for now, but in the future we will probably add more attributes to be set on tile level.

This should be the last missing feature before the editor offers a complete workflow...