### PR TITLE
Improve automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           mkdir $release_dir
           cp target/${{ matrix.target }}/release/fishfight $release_dir/
           strip $release_dir/fishfight || true
-          cp -R assets/ $release_dir/
+          cp -R assets $release_dir
           tar -czvf $artifact_path $release_dir/
 
       - name: Deploy | Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,19 +95,24 @@ jobs:
           # use-cross: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Prepare artifacts [Windows]
+        shell: bash
         if: matrix.os == 'windows-latest'
         run: |
-          cd target/${{ matrix.target }}/release
-          strip fishfight.exe
-          7z a ../../../${{ matrix.name }} fishfight.exe
-          cd -
+          mkdir -p release/assets
+          cp target/${{ matrix.target }}/release/fishfight.exe release/
+          strip release/fishfight.exe
+          cp -R assets/ release/assets/
+          7z a -tzip ${{ matrix.name }} release/
+
       - name: Prepare artifacts [Unix]
+        shell: bash
         if: matrix.os != 'windows-latest'
         run: |
-          cd target/${{ matrix.target }}/release
-          strip fishfight || true
-          tar czvf ../../../${{ matrix.name }} fishfight
-          cd -
+          mkdir -p release/assets
+          cp target/${{ matrix.target }}/release/fishfight release/
+          strip release/fishfight || true
+          cp -R assets/ release/assets/
+          tar -czvf ${{ matrix.name }} release/
 
       - name: Deploy | Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,13 +95,12 @@ jobs:
           # use-cross: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Prepare artifacts [Windows]
-        id: artifacts
         shell: bash
         if: matrix.os == 'windows-latest'
         run: |
           release_dir="fishfight-${{ env.RELEASE_VERSION }}"
           artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.zip"
-          echo "::set-output name=artifact_path::$artifact_path"
+          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
           mkdir $release_dir
           cp target/${{ matrix.target }}/release/fishfight.exe $release_dir/
           strip $release_dir/fishfight.exe
@@ -109,13 +108,12 @@ jobs:
           7z a -tzip $artifact_path $release_dir/
 
       - name: Prepare artifacts [Unix]
-        id: artifacts
         shell: bash
         if: matrix.os != 'windows-latest'
         run: |
           release_dir="fishfight-${{ env.RELEASE_VERSION }}"
           artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz"
-          echo "::set-output name=artifact_path::$artifact_path"
+          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
           mkdir $release_dir
           cp target/${{ matrix.target }}/release/fishfight $release_dir/
           strip $release_dir/fishfight || true
@@ -125,8 +123,8 @@ jobs:
       - name: Deploy | Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.artifacts.outputs.artifact_path }}
-          path: ${{ steps.artifacts.outputs.artifact_path }}
+          name: ${{ env.ARTIFACT_PATH }}
+          path: ${{ env.ARTIFACT_PATH }}
           if-no-files-found: error
 
   publish_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,19 +39,15 @@ jobs:
 
           - target: x86_64-apple-darwin
             os: macOS-latest
-            name: fishfight-x86_64-apple-darwin.tar.gz
 
           - target: aarch64-apple-darwin
             os: macOS-latest
-            name: fishfight-aarch64-apple-darwin.tar.gz
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            name: fishfight-x86_64-pc-windows-msvc.zip
 
           - target: i686-pc-windows-msvc
             os: windows-latest
-            name: fishfight-i686-pc-windows-msvc.zip
 
     runs-on: ${{ matrix.os }}
     continue-on-error: true
@@ -102,29 +98,33 @@ jobs:
         shell: bash
         if: matrix.os == 'windows-latest'
         run: |
-          release_dir="FishFight-${{ env.RELEASE_VERSION }}"
-          mkdir -p $release_dir/assets
+          release_dir="fishfight-${{ env.RELEASE_VERSION }}"
+          mkdir $release_dir
           cp target/${{ matrix.target }}/release/fishfight.exe $release_dir/
           strip $release_dir/fishfight.exe
-          cp -R assets/ $release_dir/assets/
-          7z a -tzip ${{ matrix.name }} $release_dir/
+          cp -R assets/ $release_dir/
+          7z a -tzip \
+            fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.zip \
+            $release_dir/
 
       - name: Prepare artifacts [Unix]
         shell: bash
         if: matrix.os != 'windows-latest'
         run: |
-          release_dir="FishFight-${{ env.RELEASE_VERSION }}"
-          mkdir -p $release_dir/assets
+          release_dir="fishfight-${{ env.RELEASE_VERSION }}"
+          mkdir $release_dir
           cp target/${{ matrix.target }}/release/fishfight $release_dir/
           strip $release_dir/fishfight || true
-          cp -R assets/ $release_dir/assets/
-          tar -czvf ${{ matrix.name }} $release_dir/
+          cp -R assets/ $release_dir/
+          tar -czvf \
+            fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz \
+            $release_dir/
 
       - name: Deploy | Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.name }}
-          path: ${{ matrix.name }}
+          path: fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}*
+          if-no-files-found: error
 
   publish_release:
     name: Create and Publish GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,35 +95,38 @@ jobs:
           # use-cross: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Prepare artifacts [Windows]
+        id: artifacts
         shell: bash
         if: matrix.os == 'windows-latest'
         run: |
           release_dir="fishfight-${{ env.RELEASE_VERSION }}"
+          artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.zip"
+          echo "::set-output name=artifact_path::$artifact_path"
           mkdir $release_dir
           cp target/${{ matrix.target }}/release/fishfight.exe $release_dir/
           strip $release_dir/fishfight.exe
           cp -R assets/ $release_dir/
-          7z a -tzip \
-            fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.zip \
-            $release_dir/
+          7z a -tzip $artifact_path $release_dir/
 
       - name: Prepare artifacts [Unix]
+        id: artifacts
         shell: bash
         if: matrix.os != 'windows-latest'
         run: |
           release_dir="fishfight-${{ env.RELEASE_VERSION }}"
+          artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz"
+          echo "::set-output name=artifact_path::$artifact_path"
           mkdir $release_dir
           cp target/${{ matrix.target }}/release/fishfight $release_dir/
           strip $release_dir/fishfight || true
           cp -R assets/ $release_dir/
-          tar -czvf \
-            fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz \
-            $release_dir/
+          tar -czvf $artifact_path $release_dir/
 
       - name: Deploy | Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}*
+          name: ${{ steps.artifacts.outputs.artifact_path }}
+          path: ${{ steps.artifacts.outputs.artifact_path }}
           if-no-files-found: error
 
   publish_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build
         uses: actions-rs/cargo@v1
         env:
-          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
           RUSTFLAGS: -L /usr/lib/x86_64-linux-gnu
         with:
           command: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,15 @@ jobs:
 
           # - target: x86_64-unknown-linux-musl
           #   os: ubuntu-latest
-          #   name: templa-rs-x86_64-unknown-linux-musl.tar.gz
 
           # - target: i686-unknown-linux-musl
           #   os: ubuntu-latest
-          #   name: templa-rs-i686-unknown-linux-musl.tar.gz
 
           # - target: aarch64-unknown-linux-musl
           #   os: ubuntu-latest
-          #   name: templa-rs-aarch64-unknown-linux-musl.tar.gz
 
           # - target: arm-unknown-linux-musleabihf
           #   os: ubuntu-latest
-          #   name: templa-rs-arm-unknown-linux-musleabihf.tar.gz
 
           - target: x86_64-apple-darwin
             os: macOS-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set the release version
+        shell: bash
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+
       - name: Setup Dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -98,21 +102,23 @@ jobs:
         shell: bash
         if: matrix.os == 'windows-latest'
         run: |
-          mkdir -p release/assets
-          cp target/${{ matrix.target }}/release/fishfight.exe release/
-          strip release/fishfight.exe
-          cp -R assets/ release/assets/
-          7z a -tzip ${{ matrix.name }} release/
+          release_dir="FishFight-${{ env.RELEASE_VERSION }}"
+          mkdir -p $release_dir/assets
+          cp target/${{ matrix.target }}/release/fishfight.exe $release_dir/
+          strip $release_dir/fishfight.exe
+          cp -R assets/ $release_dir/assets/
+          7z a -tzip ${{ matrix.name }} $release_dir/
 
       - name: Prepare artifacts [Unix]
         shell: bash
         if: matrix.os != 'windows-latest'
         run: |
-          mkdir -p release/assets
-          cp target/${{ matrix.target }}/release/fishfight release/
-          strip release/fishfight || true
-          cp -R assets/ release/assets/
-          tar -czvf ${{ matrix.name }} release/
+          release_dir="FishFight-${{ env.RELEASE_VERSION }}"
+          mkdir -p $release_dir/assets
+          cp target/${{ matrix.target }}/release/fishfight $release_dir/
+          strip $release_dir/fishfight || true
+          cp -R assets/ $release_dir/assets/
+          tar -czvf ${{ matrix.name }} $release_dir/
 
       - name: Deploy | Upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR tackles the following issues about the release workflow:

- `assets/` directory is now included in release artifacts (related to #296)
- artifacts are now named as `fishfight-<version>-<target>.<ext>`
- fixes #297 in 49fd53b5ee4adada9c6ac4b1d80dad8c831852ad

### Screenshots

![image](https://user-images.githubusercontent.com/24392180/145846165-fa297b0c-139c-4736-bfb9-f7f67712c2d7.png)

![image](https://user-images.githubusercontent.com/24392180/145846278-10aae734-4acf-49bb-89e1-4c5464dea59a.png)
