### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 Fish Fight source code is dual-licensed under either
 
-* MIT License (docs/LICENSE-MIT or http://opensource.org/licenses/MIT)
-* Apache License, Version 2.0 (docs/LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT License ([docs/LICENSE-MIT](docs/LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 ([docs/LICENSE-APACHE](docs/LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 
 at your option.
 
-Fish Fight media assets, unless otherwise specified (see /temp), are Copyright (c) 2020-2021 The Fish Fight Game Developers and licensed as [CC BY-NC](https://creativecommons.org/licenses/by-nc/4.0/).
+Fish Fight media assets are Copyright (c) 2020-2021 The Fish Fight Game Developers and licensed as [CC BY-NC](https://creativecommons.org/licenses/by-nc/4.0/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Fish Fight source code is dual-licensed under either
 
-* MIT License ([docs/LICENSE-MIT](docs/LICENSE-MIT) or http://opensource.org/licenses/MIT)
-* Apache License, Version 2.0 ([docs/LICENSE-APACHE](docs/LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT License (docs/LICENSE-MIT or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 (docs/LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
 
 at your option.
 


### PR DESCRIPTION
While packaging [fishfight](https://archlinux.org/packages/community/x86_64/fishfight/) for Arch Linux, I realized that LICENSE seems a bit outdated (`temp/` no longer exists) so I decided to update it.

P.S. we might want to update all licenses soon. ("2020-2022")

