### PR TITLE
Remove bundled-sdl2 feature from fishsticks dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,15 +97,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cmake"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,7 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94cb479353c0603785c834e2307440d83d196bf255f204f7f6741358de8d6a2f"
 dependencies = [
  "cfg-if",
- "cmake",
  "libc",
  "version-compare",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ macroquad-profiler = "0.1"
 
 ff-particles = { version = "0.1", features = ["serde"] }
 
-fishsticks = { version = "0.2.0", features = ["bundled-sdl2"] }
+fishsticks = "0.2.0"
 
 stunclient = { git = "https://github.com/not-fl3/rust-stunclient", default-features = false }
 


### PR DESCRIPTION
See #309

I will submit another PR shortly for updating README.md about this.
