### PR TITLE
Support loading the credits font from a custom assets directory

### DIFF
--- a/src/gui/credits.rs
+++ b/src/gui/credits.rs
@@ -1,6 +1,7 @@
 use crate::is_gamepad_btn_pressed;
 use fishsticks::{Button, GamepadContext};
 use macroquad::{experimental::collections::storage, prelude::*};
+use std::path::Path;
 
 const TEXT_X_OFFSET: f32 = 370.0;
 const MAIN_HEADER_Y_OFFSET: f32 = 300.0;
@@ -65,15 +66,20 @@ enum LabelType {
     Regular,
 }
 
-pub async fn show_game_credits() {
+pub async fn show_game_credits(assets_dir: &str) {
     let gamepad_context = storage::get::<GamepadContext>();
 
     let mut delta = 200.0;
     let credits = create_game_credits();
 
-    let font = load_ttf_font("./assets/ui/AnonymousPro-Regular.ttf")
-        .await
-        .unwrap();
+    let font = load_ttf_font(
+        Path::new(assets_dir)
+            .join("ui/AnonymousPro-Regular.ttf")
+            .to_str()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
 
     loop {
         if is_key_pressed(KeyCode::Escape)

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,8 +180,9 @@ async fn main() -> Result<()> {
                 continue 'outer;
             }
             MainMenuResult::Credits => {
+                let resources = storage::get::<Resources>();
                 start_music("thanks_for_all_the_fished");
-                gui::show_game_credits().await;
+                gui::show_game_credits(&resources.assets_dir).await;
                 stop_music();
                 continue 'outer;
             }


### PR DESCRIPTION
When `assets/` directory is located outside the current path, going to the credits screen crashes the game:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: FileError { kind: IOError(Os { code: 2, kind: NotFound, message: "No such file or directory" }), path: "./assets/ui/AnonymousPro-Regular.ttf" }', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/macroquad-0.3.13/src/text.rs:239:52
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes this issue by refactoring the `show_game_credits` function to respect any custom assets directory specified by `FISHFIGHT_ASSETS` environment variable.
