### PR TITLE
Fix gravity and jump

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -12,6 +12,7 @@ pub struct SchedulerBuilder {
 }
 
 impl SchedulerBuilder {
+    #[must_use]
     pub fn add_system(self, system: SystemFn) -> Self {
         let mut steps = self.steps;
         steps.push(system);
@@ -19,6 +20,7 @@ impl SchedulerBuilder {
         SchedulerBuilder { steps }
     }
 
+    #[must_use]
     pub fn add_thread_local(self, system: SystemFn) -> Self {
         let mut steps = self.steps;
         steps.push(system);

--- a/src/editor/gui/combobox.rs
+++ b/src/editor/gui/combobox.rs
@@ -88,6 +88,7 @@ impl ComboBoxBuilder {
         }
     }
 
+    #[must_use]
     pub fn with_label(self, label: &str) -> Self {
         ComboBoxBuilder {
             label: Some(label.to_string()),
@@ -95,6 +96,7 @@ impl ComboBoxBuilder {
         }
     }
 
+    #[must_use]
     pub fn with_ratio(self, ratio: f32) -> Self {
         ComboBoxBuilder {
             ratio: Some(ratio),

--- a/src/editor/gui/mod.rs
+++ b/src/editor/gui/mod.rs
@@ -92,6 +92,7 @@ impl EditorGui {
         }
     }
 
+    #[must_use]
     pub fn with_toolbar(self, toolbar: Toolbar) -> Self {
         let mut gui = self;
         gui.add_toolbar(toolbar);

--- a/src/editor/gui/toolbars/mod.rs
+++ b/src/editor/gui/toolbars/mod.rs
@@ -93,6 +93,7 @@ impl Toolbar {
         }
     }
 
+    #[must_use]
     pub fn with_element<E: ToolbarElement + 'static>(self, height_factor: f32, element: E) -> Self {
         let mut res = self;
         res.add_element(height_factor, element);

--- a/src/editor/gui/toolbars/tool_selector.rs
+++ b/src/editor/gui/toolbars/tool_selector.rs
@@ -36,6 +36,7 @@ impl ToolSelectorElement {
         }
     }
 
+    #[must_use]
     pub fn with_tool<T: EditorTool + 'static>(self) -> Self {
         let id = TypeId::of::<T>();
         let mut tools = self.tools;

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -79,7 +79,7 @@ impl Game {
             index,
             controller,
             character,
-        } in player_params.to_vec()
+        } in player_params.iter().cloned()
         {
             let position = map.get_random_spawn_point();
             let player = spawn_player(&mut world, index, position, controller, character);

--- a/src/gui/select_character.rs
+++ b/src/gui/select_character.rs
@@ -62,8 +62,8 @@ pub async fn show_select_characters_menu(
 
         let animations = meta
             .animations
-            .to_vec()
-            .into_iter()
+            .iter()
+            .cloned()
             .map(|a| a.into())
             .collect::<Vec<_>>();
 
@@ -256,8 +256,8 @@ pub async fn show_select_characters_menu(
 
                 let animations = meta
                     .animations
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(|a| a.into())
                     .collect::<Vec<_>>();
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -75,6 +75,7 @@ impl URect {
     }
 
     /// Returns a new `Rect` that includes all points of these two `Rect`s.
+    #[must_use]
     pub fn combine_with(self, other: URect) -> Self {
         let x = u32::min(self.x, other.x);
         let y = u32::min(self.y, other.y);
@@ -103,6 +104,7 @@ impl URect {
     }
 
     /// Translate rect origin be `offset` vector
+    #[must_use]
     pub fn offset(self, offset: UVec2) -> Self {
         URect::new(self.x + offset.x, self.y + offset.y, self.w, self.h)
     }

--- a/src/network/api.rs
+++ b/src/network/api.rs
@@ -236,6 +236,7 @@ pub struct Account {
 }
 
 impl Account {
+    #[must_use]
     pub fn remove_secrets(self) -> Self {
         Account {
             password_hash: None,

--- a/src/physics/body.rs
+++ b/src/physics/body.rs
@@ -7,9 +7,9 @@ use hecs::World;
 
 use serde::{Deserialize, Serialize};
 
-use crate::json;
 use crate::physics::GRAVITY;
 use crate::Transform;
+use crate::{json, TERMINAL_VELOCITY};
 
 const FRICTION_LERP: f32 = 0.96;
 const STOP_THRESHOLD: f32 = 1.0;
@@ -115,6 +115,10 @@ pub fn update_physics_bodies(world: &mut World) {
 
             if !body.is_on_ground && body.has_mass {
                 body.velocity.y += GRAVITY;
+
+                if body.velocity.y > TERMINAL_VELOCITY {
+                    body.velocity.y = TERMINAL_VELOCITY;
+                }
             }
 
             if !collision_world.move_h(body.actor, body.velocity.x) {

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -6,7 +6,8 @@ pub use body::*;
 
 use crate::{CollisionWorld, Map};
 
-pub const GRAVITY: f32 = 1.5;
+pub const GRAVITY: f32 = 2.5;
+pub const TERMINAL_VELOCITY: f32 = 10.0;
 
 pub fn create_collision_world(map: &Map) -> CollisionWorld {
     let tile_cnt = (map.grid_size.x * map.grid_size.y) as usize;

--- a/src/player/character.rs
+++ b/src/player/character.rs
@@ -71,7 +71,7 @@ impl PlayerCharacterMetadata {
     const DEFAULT_HEAD_THRESHOLD: f32 = 24.0;
     const DEFAULT_LEGS_THRESHOLD: f32 = 42.0;
 
-    const DEFAULT_JUMP_FORCE: f32 = 20.0;
+    const DEFAULT_JUMP_FORCE: f32 = 15.0;
     const DEFAULT_MOVE_SPEED: f32 = 5.0;
     const DEFAULT_SLIDE_SPEED_FACTOR: f32 = 3.0;
     const DEFAULT_SLIDE_DURATION: f32 = 0.1;

--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -210,8 +210,8 @@ impl From<&[(&str, Sprite)]> for SpriteSet {
 
         let map = HashMap::from_iter(
             sprites
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|(id, sprite)| (id.to_string(), sprite)),
         );
 


### PR DESCRIPTION
This tweaks gravity, adds terminal velocity and makes gravity canceled if jump is held for a certain amount of frames, after jump is initiated.

This can still be tweaked, probably, so feel free to play around with the parameters:

`crate::physics::GRAVITY` - gravity
`crate::physics::TERMINAL_VELOCITY` - terminal velocity
`crate::player::character::PlayerCharacterMetadata::DEFAULT_JUMP_FORCE` - default jump force
`crate::player::state::JUMP_FRAME_COUNT` - max number of frames without gravity
