### PR TITLE
Fix draw order

### DIFF
--- a/src/effects/active/projectiles.rs
+++ b/src/effects/active/projectiles.rs
@@ -9,13 +9,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::effects::active::triggered::TriggeredEffect;
 use crate::effects::TriggeredEffectTrigger;
-use crate::json;
 use crate::particles::{ParticleEmitter, ParticleEmitterParams};
 use crate::player::PlayerState;
+use crate::{json, DrawOrder};
 use crate::{
     CollisionWorld, PhysicsBody, Resources, RigidBody, RigidBodyParams, Sprite, SpriteMetadata,
     Transform,
 };
+
+const PROJECTILE_DRAW_ORDER: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -125,7 +127,14 @@ pub fn spawn_projectile(
     };
 
     world
-        .insert(entity, (transform, RigidBody::new(velocity, body_params)))
+        .insert(
+            entity,
+            (
+                transform,
+                RigidBody::new(velocity, body_params),
+                DrawOrder(PROJECTILE_DRAW_ORDER),
+            ),
+        )
         .unwrap();
 
     let mut particle_emitters = Vec::new();

--- a/src/effects/active/triggered.rs
+++ b/src/effects/active/triggered.rs
@@ -9,12 +9,14 @@ use crate::effects::active::spawn_active_effect;
 use crate::math::deg_to_rad;
 use crate::particles::{ParticleEmitter, ParticleEmitterParams};
 use crate::player::PlayerState;
-use crate::{json, AnimatedSpriteParams, PhysicsBodyParams};
+use crate::{json, AnimatedSpriteParams, DrawOrder, PhysicsBodyParams};
 use crate::{
     ActiveEffectMetadata, AnimatedSprite, AnimatedSpriteMetadata, CollisionWorld, PhysicsBody,
     Transform,
 };
 use crate::{Resources, Result};
+
+const TRIGGERED_EFFECT_DRAW_ORDER: u32 = 5;
 
 /// The various collision types that can trigger a `TriggeredEffect`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -106,6 +108,7 @@ pub fn spawn_triggered_effect(
                 ..Default::default()
             },
         ),
+        DrawOrder(TRIGGERED_EFFECT_DRAW_ORDER),
     ));
 
     if let Some(meta) = meta.sprite.clone() {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -23,11 +23,9 @@ use crate::player::{
 };
 use crate::Result;
 use crate::{
-    create_collision_world, debug_draw_animated_sprite_sets, debug_draw_animated_sprites,
-    debug_draw_rigid_bodies, debug_draw_sprite_sets, debug_draw_sprites, draw_animated_sprite_sets,
-    draw_animated_sprites, draw_sprite_sets, draw_sprites, exit_to_main_menu,
-    is_gamepad_btn_pressed, quit_to_desktop, update_animated_sprite_sets, update_animated_sprites,
-    update_rigid_bodies, Map, MapLayerKind, MapObjectKind, Resources,
+    create_collision_world, debug_draw_rigid_bodies, debug_draw_sprites, draw_sprites,
+    exit_to_main_menu, is_gamepad_btn_pressed, quit_to_desktop, update_animated_sprite_sets,
+    update_animated_sprites, update_rigid_bodies, Map, MapLayerKind, MapObjectKind, Resources,
 };
 
 pub use input::{collect_local_input, GameInput, GameInputScheme};
@@ -111,9 +109,6 @@ impl Game {
 
         let draws = Scheduler::builder()
             .add_thread_local(draw_sprites)
-            .add_thread_local(draw_sprite_sets)
-            .add_thread_local(draw_animated_sprites)
-            .add_thread_local(draw_animated_sprite_sets)
             .add_thread_local(draw_weapons_hud)
             .add_thread_local(draw_particle_emitters)
             .add_thread_local(draw_particle_emitter_sets)
@@ -122,9 +117,6 @@ impl Game {
         #[cfg(debug_assertions)]
         let debug_draws = Scheduler::builder()
             .add_thread_local(debug_draw_sprites)
-            .add_thread_local(debug_draw_sprite_sets)
-            .add_thread_local(debug_draw_animated_sprites)
-            .add_thread_local(debug_draw_animated_sprite_sets)
             .add_thread_local(debug_draw_physics_bodies)
             .add_thread_local(debug_draw_rigid_bodies)
             .build();

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -8,7 +8,7 @@ use macroquad::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    json, AnimatedSprite, AnimatedSpriteMetadata, AnimatedSpriteSet, CollisionWorld,
+    json, AnimatedSprite, AnimatedSpriteMetadata, AnimatedSpriteSet, CollisionWorld, DrawOrder,
     PassiveEffectMetadata, PhysicsBody, Resources, Transform,
 };
 
@@ -20,6 +20,8 @@ use crate::effects::passive::PassiveEffectParams;
 use crate::particles::ParticleEmitter;
 use crate::physics::PhysicsBodyParams;
 use crate::Result;
+
+pub const ITEMS_DRAW_ORDER: u32 = 1;
 
 pub const SPRITE_ANIMATED_SPRITE_ID: &str = "sprite";
 pub const EFFECT_ANIMATED_SPRITE_ID: &str = "effect";
@@ -204,6 +206,7 @@ pub fn spawn_item(world: &mut World, position: Vec2, meta: MapItemMetadata) -> R
                 ..Default::default()
             },
         ),
+        DrawOrder(ITEMS_DRAW_ORDER),
     ));
 
     let uses = meta.uses;

--- a/src/map/decoration.rs
+++ b/src/map/decoration.rs
@@ -5,8 +5,10 @@ use hecs::{Entity, World};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{AnimatedSprite, AnimatedSpriteMetadata};
+use crate::{AnimatedSprite, AnimatedSpriteMetadata, DrawOrder};
 use crate::{Resources, Transform};
+
+const DECORATION_DRAW_ORDER: u32 = 0;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct DecorationMetadata {
@@ -44,6 +46,7 @@ pub fn spawn_decoration(world: &mut World, position: Vec2, meta: DecorationMetad
     world.spawn((
         Decoration::new(&meta.id),
         Transform::from(position),
+        DrawOrder(DECORATION_DRAW_ORDER),
         AnimatedSprite::new(texture, frame_size, animations.as_slice(), params),
     ))
 }

--- a/src/map/sproinger.rs
+++ b/src/map/sproinger.rs
@@ -5,8 +5,11 @@ use macroquad::prelude::*;
 use hecs::{Entity, World};
 
 use crate::{
-    AnimatedSprite, Animation, PhysicsBody, QueuedAnimationAction, Resources, Result, Transform,
+    AnimatedSprite, Animation, DrawOrder, PhysicsBody, QueuedAnimationAction, Resources, Result,
+    Transform,
 };
+
+const SPROINGER_DRAW_ORDER: u32 = 2;
 
 const TEXTURE_ID: &str = "sproinger";
 
@@ -71,6 +74,7 @@ pub fn spawn_sproinger(world: &mut World, position: Vec2) -> Result<Entity> {
     let entity = world.spawn((
         Sproinger::new(),
         Transform::from(position),
+        DrawOrder(SPROINGER_DRAW_ORDER),
         AnimatedSprite::new(
             texture_res.texture,
             frame_size,

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -4,8 +4,8 @@ use macroquad::prelude::*;
 use hecs::{Entity, World};
 
 use crate::{
-    AnimatedSprite, AnimatedSpriteParams, AnimatedSpriteSet, CollisionWorld, PhysicsBody,
-    Resources, Transform,
+    AnimatedSprite, AnimatedSpriteParams, AnimatedSpriteSet, CollisionWorld, DrawOrder,
+    PhysicsBody, Resources, Transform,
 };
 
 mod animation;
@@ -127,6 +127,8 @@ pub fn spawn_player(
         AnimatedSprite::new(texture, frame_size, animations.as_slice(), params),
     )];
 
+    let draw_order = (index as u32 + 1) * 10;
+
     let size = character.collider_size.as_i32();
     let actor = storage::get_mut::<CollisionWorld>().add_actor(position, size.x, size.y);
 
@@ -145,6 +147,7 @@ pub fn spawn_player(
         PlayerAttributes::from(character),
         PlayerState::from(position),
         PlayerInventory::from(weapon_mount),
+        DrawOrder(draw_order),
         AnimatedSpriteSet::from(sprites),
         PhysicsBody::new(actor, None, body_params),
     ))

--- a/src/sprite/animated.rs
+++ b/src/sprite/animated.rs
@@ -182,18 +182,6 @@ pub fn update_animated_sprites(world: &mut World) {
     }
 }
 
-pub fn draw_animated_sprites(world: &mut World) {
-    for (_, (transform, sprite)) in world.query::<(&Transform, &AnimatedSprite)>().iter() {
-        draw_one_animated_sprite(transform, sprite);
-    }
-}
-
-pub fn debug_draw_animated_sprites(world: &mut World) {
-    for (_, (transform, sprite)) in world.query::<(&Transform, &AnimatedSprite)>().iter() {
-        debug_draw_one_animated_sprite(transform.position, sprite);
-    }
-}
-
 pub fn update_one_animated_sprite(sprite: &mut AnimatedSprite) {
     if !sprite.is_deactivated && sprite.is_playing {
         let (is_last_frame, is_looping) = {
@@ -393,24 +381,6 @@ pub fn update_animated_sprite_sets(world: &mut World) {
         for key in &sprite_set.draw_order {
             let sprite = sprite_set.map.get_mut(key).unwrap();
             update_one_animated_sprite(sprite);
-        }
-    }
-}
-
-pub fn draw_animated_sprite_sets(world: &mut World) {
-    for (_, (transform, sprite_set)) in world.query::<(&Transform, &AnimatedSpriteSet)>().iter() {
-        for key in &sprite_set.draw_order {
-            let sprite = sprite_set.map.get(key).unwrap();
-            draw_one_animated_sprite(transform, sprite);
-        }
-    }
-}
-
-pub fn debug_draw_animated_sprite_sets(world: &mut World) {
-    for (_, (transform, sprite_set)) in world.query::<(&Transform, &AnimatedSpriteSet)>().iter() {
-        for key in &sprite_set.draw_order {
-            let sprite = sprite_set.map.get(key).unwrap();
-            debug_draw_one_animated_sprite(transform.position, sprite);
         }
     }
 }


### PR DESCRIPTION
This adds a `DrawOrder` component that must be added to all drawables, which determines where in the draw order it is drawn.

For items, draw order is handled by having them use a set constant draw order when on the ground and the players draw order + 1, when equipped.
The players draw order is its index + 1, multiplied by 10, so there is room to sort equipped items more precisely, if we want to.

In the future we might want to remove the requirement of a`DrawOrder` component to have something draw and iterate through drawables without a set draw order and either draw them before or after all the ordered draws.

Also, this currently queries for all entities with a `DrawOrder` component and then queries for the possible drawable component types in a series of if/else statements. This might cause performance issues, down the line (don't have an intuitive sense of hecs performance, yet). If this is the case, we will wrap all drawables in a `Drawable` enum type component and match on that, in stead...