### PR TITLE
Reimplement passive effects

### DIFF
--- a/assets/items/blunderbass.json
+++ b/assets/items/blunderbass.json
@@ -1,5 +1,6 @@
 {
   "id": "blunderbass",
+  "name": "Blunderbass",
   "type": "weapon",
   "uses": 4,
   "cooldown": 2.0,

--- a/assets/items/blunderbuss.json
+++ b/assets/items/blunderbuss.json
@@ -1,5 +1,6 @@
 {
   "id": "blunderbuss",
+  "name": "Blunderbuss",
   "type": "weapon",
   "uses": 2,
   "cooldown": 1.25,

--- a/assets/items/cannon.json
+++ b/assets/items/cannon.json
@@ -1,5 +1,6 @@
 {
   "id": "cannon",
+  "name": "Cannon",
   "type": "weapon",
   "cooldown": 1.5,
   "attack_duration": 1.0,

--- a/assets/items/crate.json
+++ b/assets/items/crate.json
@@ -1,5 +1,6 @@
 {
   "id": "crate",
+  "name": "Crate",
   "type": "weapon",
   "uses": 1,
   "deplete_behavior": "destroy",

--- a/assets/items/grenades.json
+++ b/assets/items/grenades.json
@@ -1,5 +1,6 @@
 {
   "id": "grenades",
+  "name": "Grenades",
   "type": "weapon",
   "cooldown": 0.5,
   "uses": 3,

--- a/assets/items/kick_bomb.json
+++ b/assets/items/kick_bomb.json
@@ -1,5 +1,6 @@
 {
   "id": "kick_bomb",
+  "name": "Kick Bomb",
   "type": "weapon",
   "uses": 1,
   "deplete_behavior": "destroy",

--- a/assets/items/machine_gun.json
+++ b/assets/items/machine_gun.json
@@ -1,5 +1,6 @@
 {
   "id": "machine_gun",
+  "name": "Machine Gun",
   "type": "weapon",
   "cooldown": 0.15,
   "attack_duration": 0.1,

--- a/assets/items/mines.json
+++ b/assets/items/mines.json
@@ -1,5 +1,6 @@
 {
   "id": "mines",
+  "name": "Mines",
   "type": "weapon",
   "cooldown": 0.5,
   "uses": 3,

--- a/assets/items/musket.json
+++ b/assets/items/musket.json
@@ -1,5 +1,6 @@
 {
   "id": "musket",
+  "name": "Musket",
   "type": "weapon",
   "uses": 3,
   "cooldown": 1.0,

--- a/assets/items/sniper_rifle.json
+++ b/assets/items/sniper_rifle.json
@@ -1,5 +1,6 @@
 {
   "id": "sniper_rifle",
+  "name": "Sniper Rifle",
   "type": "weapon",
   "uses": 2,
   "cooldown": 1.5,

--- a/assets/items/sword.json
+++ b/assets/items/sword.json
@@ -1,5 +1,6 @@
 {
   "id": "sword",
+  "name": "Sword",
   "type": "weapon",
   "cooldown": 1.0,
   "sound_effect": "sword",

--- a/assets/items/turtle_shell.json
+++ b/assets/items/turtle_shell.json
@@ -1,5 +1,6 @@
 {
   "id": "turtle_shell",
+  "name": "Turtle Shell",
   "type": "item",
   "uses": 3,
   "collider_size": {
@@ -8,8 +9,11 @@
   },
   "effects": [
     {
-      "id": "turtle_shell",
-      "events": "receive_damage",
+      "name": "Turtle Shell",
+      "function_id": "turtle_shell",
+      "activated_on": [
+        "receive_damage"
+      ],
       "blocks_damage": true
     }
   ],

--- a/src/effects/passive/mod.rs
+++ b/src/effects/passive/mod.rs
@@ -4,12 +4,12 @@ use macroquad::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-use hecs::Entity;
+use hecs::{Entity, World};
 
-use crate::json::OneOrMany;
-use crate::player::PlayerEvent;
+mod turtle_shell;
 
-use crate::PlayerEventParams;
+use crate::player::PlayerEventKind;
+use crate::PlayerEvent;
 
 static mut PASSIVE_EFFECT_FUNCS: Option<HashMap<String, PassiveEffectFn>> = None;
 
@@ -30,43 +30,47 @@ pub fn get_passive_effect(id: &str) -> &PassiveEffectFn {
     try_get_passive_effect(id).unwrap()
 }
 
-pub type PassiveEffectFn = fn(player: Entity, event_params: PlayerEventParams);
+pub type PassiveEffectFn =
+    fn(world: &mut World, player_entity: Entity, item_entity: Option<Entity>, event: PlayerEvent);
 
-pub struct PassiveEffectParams {}
+pub fn init_passive_effects() {
+    let effects = unsafe { get_passive_effects_map() };
 
-impl From<PassiveEffectMetadata> for PassiveEffectParams {
-    fn from(_: PassiveEffectMetadata) -> Self {
-        PassiveEffectParams {}
-    }
+    effects.insert(
+        turtle_shell::EFFECT_FUNCTION_ID.to_string(),
+        turtle_shell::effect_function,
+    );
 }
 
 pub struct PassiveEffectInstance {
-    pub id: String,
-    pub coroutine_id: Option<String>,
-    pub events: Vec<PlayerEvent>,
+    pub name: String,
+    pub function: Option<PassiveEffectFn>,
+    pub activated_on: Vec<PlayerEventKind>,
     pub particle_effect_id: Option<String>,
     pub event_particle_effect_id: Option<String>,
     pub blocks_damage: bool,
     pub uses: Option<u32>,
-    pub item_id: Option<String>,
-    use_cnt: u32,
-    duration: Option<f32>,
-    duration_timer: f32,
+    pub item: Option<Entity>,
+    pub use_cnt: u32,
+    pub duration: Option<f32>,
+    pub duration_timer: f32,
 }
 
 impl PassiveEffectInstance {
-    pub fn new(item_id: Option<&str>, params: PassiveEffectMetadata) -> Self {
+    pub fn new(item: Option<Entity>, meta: PassiveEffectMetadata) -> Self {
+        let function = meta.function_id.map(|id| *get_passive_effect(&id));
+
         PassiveEffectInstance {
-            id: params.id,
-            coroutine_id: params.coroutine_id,
-            events: params.events.into(),
-            particle_effect_id: params.particle_effect_id,
-            event_particle_effect_id: params.event_particle_effect_id,
-            blocks_damage: params.blocks_damage,
-            uses: params.uses,
-            item_id: item_id.map(|str| str.to_string()),
+            name: meta.name,
+            function,
+            activated_on: meta.activated_on,
+            particle_effect_id: meta.particle_effect_id,
+            event_particle_effect_id: meta.event_particle_effect_id,
+            blocks_damage: meta.blocks_damage,
+            uses: meta.uses,
+            item,
             use_cnt: 0,
-            duration: params.duration,
+            duration: meta.duration,
             duration_timer: 0.0,
         }
     }
@@ -90,54 +94,15 @@ impl PassiveEffectInstance {
 
         false
     }
-
-    /*
-    pub fn on_player_event(
-        &mut self,
-        player_handle: Handle<OldPlayer>,
-        position: Vec2,
-        params: PlayerEventParams,
-    ) -> Option<Coroutine> {
-        if self.events.contains(&PlayerEvent::from(&params)) {
-            let coroutine_id = self.coroutine_id.as_ref().unwrap_or(&self.id);
-
-            if self.uses.is_some() {
-                self.use_cnt += 1;
-            }
-
-            if let Some(particle_effect_id) = &self.event_particle_effect_id {
-                let mut particle_emitters = scene::find_node_by_type::<ParticleEmitters>().unwrap();
-                particle_emitters.spawn(particle_effect_id, position);
-            }
-
-            let coroutine = get_passive_effect_coroutine(coroutine_id);
-            let res = coroutine(&self.id, self.item_id.as_deref(), player_handle, params);
-
-            return Some(res);
-        }
-
-        None
-    }
-    */
-
-    pub fn default_events() -> Vec<PlayerEvent> {
-        vec![PlayerEvent::Update]
-    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PassiveEffectMetadata {
-    /// This is the id used by instances of the effect. Unless a `coroutine_id` is specified, this
-    /// will be used to retrieve the coroutine that will be called by the effect instance when
-    /// triggered by a valid event
-    pub id: String,
-    /// This map holds the id's of the coroutines that are called by the event instance, mapped
-    /// to the `PlayerEvent` they should be called on. If no `coroutine_id` is specified, the
-    /// effect instance `id` will be used.
+    pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub coroutine_id: Option<String>,
-    /// This specifies the player events that will trigger a call of the effects coroutine.
-    pub events: OneOrMany<PlayerEvent>,
+    pub function_id: Option<String>,
+    /// This specifies the player events that will trigger an activation of the event
+    pub activated_on: Vec<PlayerEventKind>,
     /// This is the particle effect that will be spawned when the effect become active.
     #[serde(
         default,

--- a/src/effects/passive/turtle_shell.rs
+++ b/src/effects/passive/turtle_shell.rs
@@ -1,55 +1,24 @@
-use macroquad::{
-    experimental::{
-        coroutines::{start_coroutine, Coroutine},
-        scene::Handle,
-    },
-    prelude::*,
-};
+use hecs::{Entity, World};
 
-use crate::player::{OldPlayer, PlayerEventParams};
+use crate::player::{PlayerEventQueue, PlayerState};
+use crate::PlayerEvent;
 
-pub const COROUTINE_ID: &str = "turtle_shell";
+pub const EFFECT_FUNCTION_ID: &str = "turtle_shell";
 
-pub fn coroutine(
-    instance_id: &str,
-    item_id: Option<&str>,
-    player_handle: Handle<OldPlayer>,
-    event_params: PlayerEventParams,
-) -> Coroutine {
-    let instance_id = instance_id.to_string();
-    let item_id = item_id.map(|str| str.to_string());
+pub fn effect_function(
+    world: &mut World,
+    player_entity: Entity,
+    _item_entity: Option<Entity>,
+    event: PlayerEvent,
+) {
+    if let PlayerEvent::ReceiveDamage { is_from_left, .. } = event {
+        let state = world.get::<PlayerState>(player_entity).unwrap();
+        let mut events = world.get_mut::<PlayerEventQueue>(player_entity).unwrap();
 
-    let coroutine = async move {
-        if let Some(mut node) = scene::try_get_node(player_handle) {
-            if let PlayerEventParams::ReceiveDamage { is_from_right, .. } = event_params {
-                if node.body.is_facing_right == is_from_right {
-                    node.kill(is_from_right);
-                } else if item_id.is_some() {
-                    let mut is_depleted = false;
-
-                    if let Some(instance) = node.passive_effects.get(&instance_id) {
-                        if let Some(uses) = instance.uses {
-                            if uses == instance.use_cnt {
-                                is_depleted = true;
-                            }
-                        }
-                    } else {
-                        is_depleted = true;
-                    }
-
-                    let item_id = item_id.unwrap();
-
-                    if is_depleted {
-                        node.equipped_items.remove(&item_id);
-                    } else if let Some(item) = node.equipped_items.get_mut(&item_id) {
-                        if let Some(sprite) = item.sprite_animation.as_mut() {
-                            sprite.set_frame(1);
-                        }
-                    }
-                }
-            }
+        if state.is_facing_left != is_from_left {
+            events
+                .queue
+                .push(PlayerEvent::DamageBlocked { is_from_left });
         }
-    };
-
-    start_coroutine(coroutine)
+    }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -19,7 +19,8 @@ use crate::gui::{self, GAME_MENU_RESULT_MAIN_MENU, GAME_MENU_RESULT_QUIT};
 use crate::physics::{debug_draw_physics_bodies, update_physics_bodies};
 use crate::player::{
     draw_weapons_hud, spawn_player, update_player_animations, update_player_camera_box,
-    update_player_controllers, update_player_inventory, update_player_states, PlayerParams,
+    update_player_controllers, update_player_events, update_player_inventory,
+    update_player_passive_effects, update_player_states, PlayerParams,
 };
 use crate::Result;
 use crate::{
@@ -92,6 +93,8 @@ impl Game {
             .add_system(update_player_camera_box)
             .add_system(update_player_states)
             .add_system(update_player_inventory)
+            .add_system(update_player_passive_effects)
+            .add_system(update_player_events)
             .add_system(update_player_animations)
             .add_system(update_animated_sprites)
             .add_system(update_animated_sprite_sets)

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -16,7 +16,6 @@ mod weapon;
 
 pub use weapon::*;
 
-use crate::effects::passive::PassiveEffectParams;
 use crate::particles::ParticleEmitter;
 use crate::physics::PhysicsBodyParams;
 use crate::Result;
@@ -80,7 +79,8 @@ pub enum MapItemKind {
 }
 
 pub struct ItemParams {
-    pub effects: Vec<PassiveEffectParams>,
+    pub name: String,
+    pub effects: Vec<PassiveEffectMetadata>,
     pub uses: Option<u32>,
     pub duration: Option<f32>,
     pub mount_offset: Vec2,
@@ -90,7 +90,8 @@ pub struct ItemParams {
 
 pub struct Item {
     pub id: String,
-    pub effects: Vec<PassiveEffectParams>,
+    pub name: String,
+    pub effects: Vec<PassiveEffectMetadata>,
     pub uses: Option<u32>,
     pub duration: Option<f32>,
     pub mount_offset: Vec2,
@@ -104,6 +105,7 @@ impl Item {
     pub fn new(id: &str, params: ItemParams) -> Self {
         Item {
             id: id.to_string(),
+            name: params.name,
             effects: params.effects,
             uses: params.uses,
             duration: params.duration,
@@ -131,6 +133,7 @@ pub struct ItemMetadata {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct MapItemMetadata {
     pub id: String,
+    pub name: String,
     #[serde(flatten)]
     pub kind: MapItemKind,
     #[serde(with = "json::vec2_def")]
@@ -211,20 +214,18 @@ pub fn spawn_item(world: &mut World, position: Vec2, meta: MapItemMetadata) -> R
 
     let uses = meta.uses;
 
+    let name = meta.name.clone();
+
     match meta.kind {
         MapItemKind::Item { meta } => {
-            let ItemMetadata {
-                effects: meta,
-                duration,
-            } = meta;
-
-            let effects = meta.into_iter().map(|m| m.into()).collect();
+            let ItemMetadata { effects, duration } = meta;
 
             world.insert_one(
                 entity,
                 Item::new(
                     id,
                     ItemParams {
+                        name,
                         effects,
                         uses,
                         duration,
@@ -286,6 +287,7 @@ pub fn spawn_item(world: &mut World, position: Vec2, meta: MapItemMetadata) -> R
             }
 
             let params = WeaponParams {
+                name,
                 effects: meta.effects,
                 uses,
                 sound_effect,

--- a/src/items/weapon.rs
+++ b/src/items/weapon.rs
@@ -18,6 +18,7 @@ use crate::{json, QueuedAnimationAction, Transform};
 use crate::{AnimatedSpriteSet, PhysicsBody, Result};
 
 pub struct WeaponParams {
+    pub name: String,
     pub effects: Vec<ActiveEffectMetadata>,
     pub uses: Option<u32>,
     pub sound_effect: Option<Sound>,
@@ -30,6 +31,7 @@ pub struct WeaponParams {
 impl Default for WeaponParams {
     fn default() -> Self {
         WeaponParams {
+            name: "".to_string(),
             effects: Vec::new(),
             uses: None,
             sound_effect: None,
@@ -43,6 +45,7 @@ impl Default for WeaponParams {
 
 pub struct Weapon {
     pub id: String,
+    pub name: String,
     pub effects: Vec<ActiveEffectMetadata>,
     pub sound_effect: Option<Sound>,
     pub recoil: f32,
@@ -67,6 +70,7 @@ impl Weapon {
     ) -> Self {
         Weapon {
             id: id.to_string(),
+            name: params.name,
             effects: params.effects,
             recoil,
             cooldown,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,11 @@ pub use game::{
 
 pub use resources::Resources;
 
-pub use player::PlayerEventParams;
+pub use player::PlayerEvent;
 
 pub use ecs::Owner;
 
+use crate::effects::passive::init_passive_effects;
 use crate::game::GameMode;
 use crate::network::Api;
 use crate::resources::load_resources;
@@ -125,6 +126,8 @@ async fn main() -> Result<()> {
         let gamepad_system = fishsticks::GamepadContext::init().unwrap();
         storage::store(gamepad_system);
     }
+
+    init_passive_effects();
 
     'outer: loop {
         match gui::show_main_menu().await {

--- a/src/player/events.rs
+++ b/src/player/events.rs
@@ -1,44 +1,34 @@
-use hecs::Entity;
+use hecs::{Entity, World};
+use macroquad::time::get_frame_time;
 
+use crate::player::PlayerState;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PlayerEvent {
-    Update,
-    ReceiveDamage,
-    GiveDamage,
-    Incapacitated,
-    Collision,
+#[derive(Default)]
+pub struct PlayerEventQueue {
+    pub queue: Vec<PlayerEvent>,
 }
 
-impl From<&PlayerEventParams> for PlayerEvent {
-    fn from(params: &PlayerEventParams) -> Self {
-        use PlayerEventParams::*;
-
-        match params {
-            Update { .. } => Self::Update,
-            ReceiveDamage { .. } => Self::ReceiveDamage,
-            GiveDamage { .. } => Self::GiveDamage,
-            Incapacitated { .. } => Self::Incapacitated,
-            Collision { .. } => Self::Collision,
-        }
+impl PlayerEventQueue {
+    pub fn new() -> Self {
+        PlayerEventQueue { queue: Vec::new() }
     }
 }
 
-/// This holds the parameters for each `PlayerEvent` variant
-pub enum PlayerEventParams {
+#[derive(Clone)]
+pub enum PlayerEvent {
     Update {
         dt: f32,
     },
     ReceiveDamage {
-        is_from_right: bool,
+        is_from_left: bool,
         damage_from: Option<Entity>,
-        is_damage_blocked: bool,
     },
     GiveDamage {
-        damage_to: Entity,
-        is_damage_blocked: bool,
+        damage_to: Option<Entity>,
+    },
+    DamageBlocked {
+        is_from_left: bool,
     },
     Incapacitated {
         incapacitated_by: Option<Entity>,
@@ -47,4 +37,59 @@ pub enum PlayerEventParams {
         is_new: bool,
         collision_with: Entity,
     },
+}
+
+/// This is used in JSON to specify which event types an effect should apply to
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlayerEventKind {
+    Update,
+    ReceiveDamage,
+    GiveDamage,
+    DamageBlocked,
+    Incapacitated,
+    Collision,
+}
+
+impl From<&PlayerEvent> for PlayerEventKind {
+    fn from(params: &PlayerEvent) -> Self {
+        use PlayerEvent::*;
+
+        match params {
+            Update { .. } => Self::Update,
+            ReceiveDamage { .. } => Self::ReceiveDamage,
+            GiveDamage { .. } => Self::GiveDamage,
+            DamageBlocked { .. } => Self::DamageBlocked,
+            Incapacitated { .. } => Self::Incapacitated,
+            Collision { .. } => Self::Collision,
+        }
+    }
+}
+
+pub fn update_player_events(world: &mut World) {
+    for (_, (state, events)) in world.query_mut::<(&mut PlayerState, &mut PlayerEventQueue)>() {
+        let dt = get_frame_time();
+
+        events.queue.push(PlayerEvent::Update { dt });
+
+        let mut damage_blocked_left = false;
+        let mut damage_blocked_right = false;
+
+        for event in events.queue.iter() {
+            if let &PlayerEvent::DamageBlocked { is_from_left } = event {
+                damage_blocked_left = damage_blocked_left || is_from_left;
+                damage_blocked_right = damage_blocked_right || !is_from_left;
+            }
+        }
+
+        while let Some(event) = events.queue.pop() {
+            if let PlayerEvent::ReceiveDamage { is_from_left, .. } = event {
+                if (is_from_left && !damage_blocked_left)
+                    || (!is_from_left && !damage_blocked_right)
+                {
+                    state.is_dead = true;
+                }
+            }
+        }
+    }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -147,6 +147,7 @@ pub fn spawn_player(
         PlayerAttributes::from(character),
         PlayerState::from(position),
         PlayerInventory::from(weapon_mount),
+        PlayerEventQueue::new(),
         DrawOrder(draw_order),
         AnimatedSpriteSet::from(sprites),
         PhysicsBody::new(actor, None, body_params),


### PR DESCRIPTION
This adds passive effects back, after the ECS refactor. It also contains an example implementation of an item using passive effects (turtle shell)