### PR TITLE
Add debug draw for collider effects and remove segmets from circle collider

### DIFF
--- a/assets/items/sword.json
+++ b/assets/items/sword.json
@@ -6,12 +6,9 @@
   "sound_effect": "sword",
   "effects": [
     {
-      "type": "circle_collider",
-      "radius": 65,
-      "segment": {
-        "x": 1,
-        "y": -1
-      }
+      "type": "rect_collider",
+      "width": 65,
+      "height": 60
     }
   ],
   "collider_size": {
@@ -21,6 +18,10 @@
   "mount_offset": {
     "x": -20,
     "y": -64
+  },
+  "effect_offset": {
+    "x": 0,
+    "y": 33
   },
   "sprite": {
     "texture": "sword",

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -31,6 +31,7 @@ use crate::{
 
 pub use input::{collect_local_input, GameInput, GameInputScheme};
 
+use crate::effects::active::debug_draw_active_effects;
 use crate::effects::active::projectiles::update_projectiles;
 use crate::effects::active::triggered::update_triggered_effects;
 use crate::items::spawn_item;
@@ -118,6 +119,7 @@ impl Game {
             .add_thread_local(debug_draw_sprites)
             .add_thread_local(debug_draw_physics_bodies)
             .add_thread_local(debug_draw_rigid_bodies)
+            .add_thread_local(debug_draw_active_effects)
             .build();
 
         Game {

--- a/src/player/state.rs
+++ b/src/player/state.rs
@@ -136,11 +136,9 @@ pub fn update_player_states(world: &mut World) {
         if state.is_dead || state.is_attacking || state.is_incapacitated || state.is_sliding {
             body.has_friction = true;
 
-            if state.is_attacking {
-                state.is_jumping = false;
-                state.jump_frame_counter = 0;
-                body.has_mass = true;
-            }
+            state.is_jumping = false;
+            state.jump_frame_counter = 0;
+            body.has_mass = true;
         } else {
             body.has_friction = false;
 


### PR DESCRIPTION
This adds debug draw for active effect colliders (CircleCollider and RectCollider), removes segments from CircleCollider and replaces segmented CircleCollider with a RectCollider on sword