### PR TITLE
Update CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,5 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: --target=${{ matrix.config.target }} ${{ matrix.profile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: Continuous integration
+
 on:
   push:
     branches:
@@ -9,8 +11,6 @@ on:
     paths-ignore:
       - "**.md"
       - "**.json"
-
-name: Compilation check
 
 jobs:
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,14 @@ jobs:
         profile: ["", --release]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Dependencies
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --allow-unauthenticated -y -qq \
+           libasound2-dev libgl1-mesa-dev libx11-dev libxi-dev
       - name: Cache Cargo dependencies
         uses: actions/cache@v2
         with:
@@ -59,7 +66,14 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.config.target }}
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.config.target }} ${{ matrix.profile }}
+          args: --locked --target ${{ matrix.config.target }} ${{ matrix.profile }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,43 +10,17 @@ on:
 jobs:
   build_release:
     name: Build release binaries
+    runs-on: ${{ matrix.config.os }}
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            name: fishfight-x86_64-unknown-linux-gnu.tar.gz
-
-          # https://github.com/actions-rs/cargo/issues/115
-          # Not able to use libs for linking: asound, GL, X11 and Xi in rust-embedded/cross.
-
-          # - target: x86_64-unknown-linux-musl
-          #   os: ubuntu-latest
-
-          # - target: i686-unknown-linux-musl
-          #   os: ubuntu-latest
-
-          # - target: aarch64-unknown-linux-musl
-          #   os: ubuntu-latest
-
-          # - target: arm-unknown-linux-musleabihf
-          #   os: ubuntu-latest
-
-          - target: x86_64-apple-darwin
-            os: macOS-latest
-
-          - target: aarch64-apple-darwin
-            os: macOS-latest
-
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-
-          - target: i686-pc-windows-msvc
-            os: windows-latest
-
-    runs-on: ${{ matrix.os }}
-    continue-on-error: true
+        config:
+          - { os: ubuntu-latest, target: "x86_64-unknown-linux-gnu" }
+          - { os: macos-latest, target: "x86_64-apple-darwin" }
+          - { os: macos-latest, target: "aarch64-apple-darwin" }
+          - { os: windows-latest, target: "x86_64-pc-windows-msvc" }
+          - { os: windows-latest, target: "i686-pc-windows-msvc" }
 
     steps:
       - name: Checkout
@@ -57,7 +31,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
 
       - name: Setup Dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.config.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install --allow-unauthenticated -y -qq \
@@ -77,7 +51,7 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-          target: ${{ matrix.target }}
+          target: ${{ matrix.config.target }}
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -86,32 +60,30 @@ jobs:
           RUSTFLAGS: -L /usr/lib/x86_64-linux-gnu
         with:
           command: build
-          args: --release --locked --target ${{ matrix.target }}
-          # https://github.com/actions-rs/cargo/issues/115
-          # use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+          args: --release --locked --target ${{ matrix.config.target }}
 
       - name: Prepare artifacts [Windows]
         shell: bash
-        if: matrix.os == 'windows-latest'
+        if: matrix.config.os == 'windows-latest'
         run: |
           release_dir="fishfight-${{ env.RELEASE_VERSION }}"
-          artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.zip"
+          artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.config.target }}.zip"
           echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
           mkdir $release_dir
-          cp target/${{ matrix.target }}/release/fishfight.exe $release_dir/
+          cp target/${{ matrix.config.target }}/release/fishfight.exe $release_dir/
           strip $release_dir/fishfight.exe
           cp -R assets/ $release_dir/
           7z a -tzip $artifact_path $release_dir/
 
       - name: Prepare artifacts [Unix]
         shell: bash
-        if: matrix.os != 'windows-latest'
+        if: matrix.config.os != 'windows-latest'
         run: |
           release_dir="fishfight-${{ env.RELEASE_VERSION }}"
-          artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.target }}.tar.gz"
+          artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.config.target }}.tar.gz"
           echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
           mkdir $release_dir
-          cp target/${{ matrix.target }}/release/fishfight $release_dir/
+          cp target/${{ matrix.config.target }}/release/fishfight $release_dir/
           strip $release_dir/fishfight || true
           cp -R assets $release_dir
           tar -czvf $artifact_path $release_dir/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,17 +3,16 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
-      - '**.json'
+      - "**.md"
+      - "**.json"
   pull_request:
     paths-ignore:
-      - '**.md'
-      - '**.json'
+      - "**.md"
+      - "**.json"
 
 name: Compilation check
 
 jobs:
-
   fmt:
     runs-on: ubuntu-latest
     name: Formatting
@@ -43,10 +42,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, target: 'x86_64-unknown-linux-gnu' }
-          - { os: macos-latest, target: 'x86_64-apple-darwin' }
-          - { os: windows-latest, target: 'x86_64-pc-windows-msvc' }
-        profile: ['' , --release]
+          - { os: ubuntu-latest, target: "x86_64-unknown-linux-gnu" }
+          - { os: macos-latest, target: "x86_64-apple-darwin" }
+          - { os: macos-latest, target: "aarch64-apple-darwin" }
+          - { os: windows-latest, target: "x86_64-pc-windows-msvc" }
+          - { os: windows-latest, target: "i686-pc-windows-msvc" }
+        profile: ["", --release]
 
     steps:
       - uses: actions/checkout@v2
@@ -62,4 +63,3 @@ jobs:
         with:
           command: check
           args: --target=${{ matrix.config.target }} ${{ matrix.profile }}
-            

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94cb479353c0603785c834e2307440d83d196bf255f204f7f6741358de8d6a2f"
 dependencies = [
  "cfg-if",
+ "cmake",
  "libc",
  "version-compare",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ macroquad = { version = "0.3.10" }
 macroquad-platformer = "0.1"
 ff-particles = { version = "0.1", features = ["serde"] }
 hecs = "0.7.1"
-fishsticks = "0.2.0"
+fishsticks = { version = "0.2.0", features = ["bundled-sdl2"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ pacman -S fishfight
 2. Clone this repository: `git clone https://github.com/fishfight/FishFight.git`
 3. `cargo run`
 
-If you get compilation errors, make sure you have [SDL2](https://www.libsdl.org/download-2.0.php) installed on your system.
-
 ## Default key bindings
 
 Keyboard left:


### PR DESCRIPTION
This PR does the following changes:

- `bundled-sdl2` feature is now enabled for `fishsticks` dependency (required for the release workflow)
- same targets are used for both CI (`ci.yml`) and CD (`release.yml`) workflows (closes #127 )

And now we should be all set for the upcoming release!