### PR TITLE
Some cleanup of player state

### DIFF
--- a/network-core/src/lib.rs
+++ b/network-core/src/lib.rs
@@ -97,7 +97,7 @@ pub enum LobbyState {
 pub struct Player {
     pub id: Id,
     pub username: String,
-    pub state: Vec<PlayerState>,
+    pub state: Vec<ClientState>,
 }
 
 impl Player {
@@ -113,7 +113,7 @@ impl Player {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde_json", serde(rename_all = "snake_case"))]
-pub enum PlayerState {
+pub enum ClientState {
     Joined,
     Ready,
     Playing,

--- a/src/effects/active/projectiles.rs
+++ b/src/effects/active/projectiles.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::effects::active::triggered::TriggeredEffect;
 use crate::effects::TriggeredEffectTrigger;
 use crate::particles::{ParticleEmitter, ParticleEmitterMetadata};
-use crate::player::{on_player_damage, PlayerState};
+use crate::player::{on_player_damage, Player, PlayerState};
 use crate::{json, Drawable, PassiveEffectInstance, PassiveEffectMetadata, SpriteParams};
 use crate::{
     CollisionWorld, PhysicsBody, Resources, RigidBody, RigidBodyParams, SpriteMetadata, Transform,
@@ -235,12 +235,12 @@ pub fn fixed_update_projectiles(world: &mut World) {
         let rect = body.as_rect(transform.position);
         for (other, other_rect) in &bodies {
             if rect.overlaps(other_rect) {
-                if let Ok(mut state) = world.get_mut::<PlayerState>(*other) {
-                    if !state.is_dead {
+                if let Ok(mut player) = world.get_mut::<Player>(*other) {
+                    if player.state != PlayerState::Dead {
                         for meta in projectile.passive_effects.clone().into_iter() {
                             let effect_instance = PassiveEffectInstance::new(None, meta);
 
-                            state.passive_effects.push(effect_instance);
+                            player.passive_effects.push(effect_instance);
                         }
 
                         if projectile.is_lethal {

--- a/src/effects/active/triggered.rs
+++ b/src/effects/active/triggered.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::effects::active::spawn_active_effect;
 use crate::math::deg_to_rad;
 use crate::particles::{ParticleEmitter, ParticleEmitterMetadata};
-use crate::player::PlayerState;
+use crate::player::{Player, PlayerState};
 use crate::Result;
 use crate::{json, Drawable, PhysicsBodyParams};
 use crate::{ActiveEffectMetadata, AnimatedSpriteMetadata, CollisionWorld, PhysicsBody, Transform};
@@ -159,13 +159,13 @@ pub fn fixed_update_triggered_effects(world: &mut World) {
     let mut to_trigger = Vec::new();
 
     let players = world
-        .query::<(&PlayerState, &Transform, &PhysicsBody)>()
+        .query::<(&Player, &Transform, &PhysicsBody)>()
         .iter()
-        .filter_map(|(e, (state, transform, body))| {
-            if state.is_dead {
+        .filter_map(|(e, (player, transform, body))| {
+            if player.state == PlayerState::Dead {
                 None
             } else {
-                Some((e, state.is_facing_left, transform.position, body.size))
+                Some((e, player.is_facing_left, transform.position, body.size))
             }
         })
         .collect::<Vec<_>>();

--- a/src/effects/passive/turtle_shell.rs
+++ b/src/effects/passive/turtle_shell.rs
@@ -1,6 +1,6 @@
 use hecs::{Entity, World};
 
-use crate::player::{PlayerEventQueue, PlayerState};
+use crate::player::{Player, PlayerEventQueue};
 use crate::PlayerEvent;
 
 pub const EFFECT_FUNCTION_ID: &str = "turtle_shell";
@@ -12,10 +12,10 @@ pub fn effect_function(
     event: PlayerEvent,
 ) {
     if let PlayerEvent::ReceiveDamage { is_from_left, .. } = event {
-        let state = world.get::<PlayerState>(player_entity).unwrap();
+        let player = world.get::<Player>(player_entity).unwrap();
         let mut events = world.get_mut::<PlayerEventQueue>(player_entity).unwrap();
 
-        if state.is_facing_left != is_from_left {
+        if player.is_facing_left != is_from_left {
             events
                 .queue
                 .push(PlayerEvent::DamageBlocked { is_from_left });

--- a/src/items.rs
+++ b/src/items.rs
@@ -17,7 +17,7 @@ use crate::effects::active::spawn_active_effect;
 
 use crate::particles::{ParticleEmitter, ParticleEmitterMetadata};
 use crate::physics::PhysicsBodyParams;
-use crate::player::{PlayerInventory, PlayerState, IDLE_ANIMATION_ID};
+use crate::player::{Player, PlayerInventory, IDLE_ANIMATION_ID};
 use crate::Result;
 
 pub const ITEMS_DRAW_ORDER: u32 = 1;
@@ -381,12 +381,12 @@ pub fn fire_weapon(world: &mut World, entity: Entity, owner: Entity) -> Result<(
         let mut weapon = world.get_mut::<Weapon>(entity).unwrap();
 
         if weapon.cooldown_timer >= weapon.cooldown {
-            let mut owner_state = world.get_mut::<PlayerState>(owner).unwrap();
+            let mut player = world.get_mut::<Player>(owner).unwrap();
 
             {
                 let mut owner_body = world.get_mut::<PhysicsBody>(owner).unwrap();
 
-                if owner_state.is_facing_left {
+                if player.is_facing_left {
                     owner_body.velocity.x = weapon.recoil;
                 } else {
                     owner_body.velocity.x = -weapon.recoil;
@@ -397,17 +397,17 @@ pub fn fire_weapon(world: &mut World, entity: Entity, owner: Entity) -> Result<(
 
                 origin = owner_transform.position
                     + owner_inventory
-                        .get_weapon_mount(owner_state.is_facing_left, owner_state.is_upside_down);
+                        .get_weapon_mount(player.is_facing_left, player.is_upside_down);
 
                 let mut offset = weapon.mount_offset + weapon.effect_offset;
-                if owner_state.is_facing_left {
+                if player.is_facing_left {
                     offset.x = -offset.x;
                 }
 
                 origin += offset;
             }
 
-            owner_state.attack_timer = weapon.attack_duration;
+            player.attack_timer = weapon.attack_duration;
 
             weapon.use_cnt += 1;
 

--- a/src/player/events.rs
+++ b/src/player/events.rs
@@ -1,7 +1,7 @@
 use hecs::{Entity, World};
 use macroquad::time::get_frame_time;
 
-use crate::player::PlayerState;
+use crate::player::{Player, PlayerState};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
@@ -67,7 +67,7 @@ impl From<&PlayerEvent> for PlayerEventKind {
 }
 
 pub fn update_player_events(world: &mut World) {
-    for (_, (state, events)) in world.query_mut::<(&mut PlayerState, &mut PlayerEventQueue)>() {
+    for (_, (player, events)) in world.query_mut::<(&mut Player, &mut PlayerEventQueue)>() {
         let dt = get_frame_time();
 
         events.queue.push(PlayerEvent::Update { dt });
@@ -87,7 +87,7 @@ pub fn update_player_events(world: &mut World) {
                 if (is_from_left && !damage_blocked_left)
                     || (!is_from_left && !damage_blocked_right)
                 {
-                    state.is_dead = true;
+                    player.state = PlayerState::Dead;
                 }
             }
         }

--- a/src/player/state.rs
+++ b/src/player/state.rs
@@ -5,163 +5,109 @@ use macroquad::prelude::*;
 use hecs::{Entity, World};
 
 use crate::player::{
-    PlayerAttributes, PlayerController, PlayerEventQueue, JUMP_SOUND_ID, LAND_SOUND_ID,
+    Player, PlayerAttributes, PlayerController, PlayerEventQueue, JUMP_SOUND_ID, LAND_SOUND_ID,
     RESPAWN_DELAY,
 };
-use crate::{
-    CollisionWorld, GameCamera, Item, Map, PassiveEffectInstance, PhysicsBody, PlayerEvent,
-    Resources, Transform,
-};
-
-const JUMP_FRAME_COUNT: u16 = 8;
-
-pub struct PlayerState {
-    pub camera_box: Rect,
-    pub passive_effects: Vec<PassiveEffectInstance>,
-    pub is_facing_left: bool,
-    pub is_upside_down: bool,
-    pub is_jumping: bool,
-    pub is_floating: bool,
-    pub is_sliding: bool,
-    pub is_crouching: bool,
-    pub is_attacking: bool,
-    pub is_incapacitated: bool,
-    pub is_dead: bool,
-    pub jump_frame_counter: u16,
-    pub pickup_grace_timer: f32,
-    pub incapacitation_timer: f32,
-    pub attack_timer: f32,
-    pub respawn_timer: f32,
-}
-
-impl From<Vec2> for PlayerState {
-    fn from(position: Vec2) -> Self {
-        let camera_box = Rect::new(position.x - 30.0, position.y - 150.0, 100.0, 210.0);
-
-        PlayerState {
-            camera_box,
-            passive_effects: Vec::new(),
-            is_facing_left: false,
-            is_upside_down: false,
-            is_jumping: false,
-            is_floating: false,
-            is_sliding: false,
-            is_crouching: false,
-            is_attacking: false,
-            is_incapacitated: false,
-            is_dead: false,
-            jump_frame_counter: 0,
-            pickup_grace_timer: 0.0,
-            attack_timer: 0.0,
-            incapacitation_timer: 0.0,
-            respawn_timer: 0.0,
-        }
-    }
-}
-
-pub fn update_player_camera_box(world: &mut World) {
-    for (_, (transform, state)) in world.query_mut::<(&Transform, &mut PlayerState)>() {
-        let rect = Rect::new(transform.position.x, transform.position.y, 32.0, 60.0);
-
-        if rect.x < state.camera_box.x {
-            state.camera_box.x = rect.x;
-        }
-
-        if rect.x + rect.w > state.camera_box.x + state.camera_box.w {
-            state.camera_box.x = rect.x + rect.w - state.camera_box.w;
-        }
-
-        if rect.y < state.camera_box.y {
-            state.camera_box.y = rect.y;
-        }
-
-        if rect.y + rect.h > state.camera_box.y + state.camera_box.h {
-            state.camera_box.y = rect.y + rect.h - state.camera_box.h;
-        }
-
-        let mut camera = storage::get_mut::<GameCamera>();
-        camera.add_player_rect(state.camera_box);
-    }
-}
+use crate::{CollisionWorld, Item, Map, PhysicsBody, PlayerEvent, Resources, Transform};
 
 const SLIDE_STOP_THRESHOLD: f32 = 2.0;
+const JUMP_FRAME_COUNT: u16 = 8;
 const PLATFORM_JUMP_FORCE_MULTIPLIER: f32 = 0.2;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum PlayerState {
+    None,
+    Jumping,
+    Floating,
+    Crouching,
+    Sliding,
+    Incapacitated,
+    Dead,
+}
+
+impl Default for PlayerState {
+    fn default() -> Self {
+        PlayerState::None
+    }
+}
 
 pub fn update_player_states(world: &mut World) {
     let query = world.query_mut::<(
         &mut Transform,
+        &mut Player,
         &PlayerController,
         &PlayerAttributes,
-        &mut PlayerState,
         &mut PhysicsBody,
     )>();
-    for (_, (transform, controller, attributes, state, body)) in query {
+    for (_, (transform, player, controller, attributes, body)) in query {
         // Timers
         let dt = get_frame_time();
 
-        state.attack_timer -= dt;
-        if state.attack_timer <= 0.0 {
-            state.attack_timer = 0.0;
+        player.attack_timer -= dt;
+        if player.attack_timer <= 0.0 {
+            player.attack_timer = 0.0;
         }
 
-        state.is_attacking = state.attack_timer > 0.0;
+        player.is_attacking = player.attack_timer > 0.0;
 
-        state.pickup_grace_timer += dt;
+        player.pickup_grace_timer += dt;
 
-        if state.is_dead {
-            state.respawn_timer += dt;
+        if player.state == PlayerState::Dead {
+            player.respawn_timer += dt;
 
-            state.passive_effects.clear();
+            player.passive_effects.clear();
 
-            if state.respawn_timer >= RESPAWN_DELAY {
-                state.is_dead = false;
-                state.respawn_timer = 0.0;
+            if player.respawn_timer >= RESPAWN_DELAY {
+                player.state = PlayerState::None;
+                player.respawn_timer = 0.0;
 
                 let map = storage::get::<Map>();
                 transform.position = map.get_random_spawn_point();
             }
-        } else if state.is_incapacitated {
-            state.incapacitation_timer += dt;
+        } else if player.state == PlayerState::Incapacitated {
+            player.incapacitation_timer += dt;
 
-            if state.incapacitation_timer >= attributes.incapacitation_duration {
-                state.is_incapacitated = false;
-                state.incapacitation_timer = 0.0;
+            if player.incapacitation_timer >= attributes.incapacitation_duration {
+                player.state = PlayerState::None;
+                player.incapacitation_timer = 0.0;
             }
         }
 
-        if state.is_sliding && body.velocity.x.abs() <= SLIDE_STOP_THRESHOLD {
+        if player.state == PlayerState::Sliding && body.velocity.x.abs() <= SLIDE_STOP_THRESHOLD {
             body.velocity.x = 0.0;
-            state.is_sliding = false;
+            player.state = PlayerState::None;
         }
 
         // Integration
-        if state.is_dead || state.is_attacking || state.is_incapacitated || state.is_sliding {
+        if player.is_attacking
+            || matches!(
+                player.state,
+                PlayerState::Dead | PlayerState::Incapacitated | PlayerState::Sliding
+            )
+        {
             body.has_friction = true;
 
-            state.is_jumping = false;
-            state.jump_frame_counter = 0;
+            player.jump_frame_counter = 0;
             body.has_mass = true;
         } else {
             body.has_friction = false;
 
             if controller.move_direction.x < 0.0 {
-                state.is_facing_left = true;
+                player.is_facing_left = true;
             } else if controller.move_direction.x > 0.0 {
-                state.is_facing_left = false;
+                player.is_facing_left = false;
             }
-
-            state.is_crouching = false;
 
             if controller.should_slide {
                 let velocity = attributes.move_speed * attributes.slide_speed_factor;
 
-                if state.is_facing_left {
+                if player.is_facing_left {
                     body.velocity.x = -velocity;
                 } else {
                     body.velocity.x = velocity;
                 }
 
-                state.is_sliding = true;
+                player.state = PlayerState::Sliding;
             } else {
                 if controller.move_direction.x < 0.0 {
                     body.velocity.x = -attributes.move_speed;
@@ -173,8 +119,8 @@ pub fn update_player_states(world: &mut World) {
 
                 if controller.should_crouch {
                     if body.is_on_ground {
-                        state.is_crouching = true;
                         body.velocity.x = 0.0;
+                        player.state = PlayerState::Crouching;
                     } else {
                         let mut collision_world = storage::get_mut::<CollisionWorld>();
                         collision_world.descent(body.actor);
@@ -190,38 +136,43 @@ pub fn update_player_states(world: &mut World) {
 
                     body.velocity.y = -jump_force;
 
-                    state.is_jumping = true;
+                    player.state = PlayerState::Jumping;
 
                     let resources = storage::get::<Resources>();
                     let sound = resources.sounds[JUMP_SOUND_ID];
 
                     play_sound_once(sound);
-                } else if state.is_jumping {
-                    state.jump_frame_counter += 1;
+                } else if player.state == PlayerState::Jumping {
+                    player.jump_frame_counter += 1;
 
-                    if controller.should_float && state.jump_frame_counter <= JUMP_FRAME_COUNT {
+                    if controller.should_float && player.jump_frame_counter <= JUMP_FRAME_COUNT {
                         body.has_mass = false;
                     } else {
-                        state.is_jumping = false;
-                        state.jump_frame_counter = 0;
+                        if matches!(player.state, PlayerState::Jumping | PlayerState::Floating) {
+                            player.state = PlayerState::None;
+                        }
+
+                        player.jump_frame_counter = 0;
                         body.has_mass = true;
                     }
                 }
 
                 if !body.is_on_ground && body.velocity.y > 0.0 {
-                    state.is_floating = controller.should_float;
-
-                    if state.is_floating {
+                    if controller.should_float {
                         body.velocity.y *= attributes.float_gravity_factor;
+                        player.state = PlayerState::Floating;
                     }
-                } else {
-                    state.is_floating = false;
+                } else if player.state == PlayerState::Floating {
+                    player.state = PlayerState::None;
                 }
             }
 
             if body.is_on_ground && !body.was_on_ground {
-                state.is_jumping = false;
-                state.jump_frame_counter = 0;
+                if matches!(player.state, PlayerState::Jumping | PlayerState::Floating) {
+                    player.state = PlayerState::None;
+                }
+
+                player.jump_frame_counter = 0;
                 body.has_mass = true;
 
                 let resources = storage::get::<Resources>();
@@ -236,24 +187,23 @@ pub fn update_player_states(world: &mut World) {
 pub fn update_player_passive_effects(world: &mut World) {
     let mut function_calls = Vec::new();
 
-    for (entity, (state, events)) in world
-        .query::<(&mut PlayerState, &mut PlayerEventQueue)>()
-        .iter()
-    {
+    for (entity, (player, events)) in world.query::<(&mut Player, &mut PlayerEventQueue)>().iter() {
         let dt = get_frame_time();
 
-        for effect in &mut state.passive_effects {
+        for effect in &mut player.passive_effects {
             effect.duration_timer += dt;
         }
 
-        state.passive_effects.retain(|effect| !effect.is_depleted());
+        player
+            .passive_effects
+            .retain(|effect| !effect.is_depleted());
 
         events.queue.push(PlayerEvent::Update { dt });
 
         for event in events.queue.iter() {
             let kind = event.into();
 
-            for effect in &mut state.passive_effects {
+            for effect in &mut player.passive_effects {
                 if effect.activated_on.contains(&kind) {
                     effect.use_cnt += 1;
 


### PR DESCRIPTION
This removes the `PlayerState` component and moves most of its content to the `Player` component, so that the name `PlayerState` can be used for a state enum (held by the `Player` component) in stead.