### PR TITLE
Remove schema files from release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           mkdir $release_dir
           cp target/${{ matrix.config.target }}/release/fishfight.exe $release_dir/
           strip $release_dir/fishfight.exe
+          find assets -name "*.schema.json" -exec rm -f {} \;
           cp -R assets/ $release_dir/
           7z a -tzip $artifact_path $release_dir/
 
@@ -85,6 +86,7 @@ jobs:
           mkdir $release_dir
           cp target/${{ matrix.config.target }}/release/fishfight $release_dir/
           strip $release_dir/fishfight || true
+          find assets -name "*.schema.json" -exec rm -f {} \;
           cp -R assets $release_dir
           tar -czvf $artifact_path $release_dir/
 


### PR DESCRIPTION
This PR updates release workflow for creating release archives that do not involve JSON schemas since they are not needed at runtime.
