### PR TITLE
Mod loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+Cargo.toml
 src/.DS_Store
 .DS_Store
 /.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 [features]
 default = []
 
-[profile.dev.package."*"]
-opt-level = 3
-
 [workspace]
 members = ["core"]
+
+[profile.dev.package."*"]
+opt-level = 3
 
 [dependencies]
 core = { path = "./core", package = "fishfight-core", features = ["serde", "serde_json"] }

--- a/core/src/network/api.rs
+++ b/core/src/network/api.rs
@@ -74,8 +74,8 @@ pub struct MockApiBackend {
 impl MockApiBackend {
     pub fn new() -> Self {
         let players = vec![
-            Player::new(&Id::from("1"), "oasf"),
-            Player::new(&Id::from("2"), "other player"),
+            Player::new(&Id::from("1"), "Player One"),
+            Player::new(&Id::from("2"), "Player Two"),
         ];
 
         let mut sessions = HashMap::new();

--- a/core/src/network/api.rs
+++ b/core/src/network/api.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use crate::Result;
 
-use super::{Id, Lobby, Player, RequestStatus};
+use super::{Id, Lobby, NetworkEvent, Player, RequestStatus};
 
 static mut API_INSTANCE: Option<Api> = None;
 
@@ -41,6 +41,12 @@ impl Api {
 
         api.backend.get_lobby(id).await
     }
+
+    pub fn next_event() -> Option<NetworkEvent> {
+        let api = Self::get_instance();
+
+        api.backend.next_event()
+    }
 }
 
 /// This trait should be implemented by all backend implementations
@@ -52,6 +58,8 @@ pub trait ApiBackend {
     async fn get_player(&mut self, id: &Id) -> Result<Player>;
     /// Get `Lobby` with the specified `id`
     async fn get_lobby(&mut self, id: &Id) -> Result<Lobby>;
+    /// Get the next event in the event queue
+    fn next_event(&mut self) -> Option<NetworkEvent>;
 }
 
 /// This is used as a placeholder for when no external backend implementation is available.
@@ -109,5 +117,9 @@ impl ApiBackend for MockApiBackend {
         } else {
             Err(RequestStatus::NotFound.into())
         }
+    }
+
+    fn next_event(&mut self) -> Option<NetworkEvent> {
+        None
     }
 }

--- a/core/src/network/api.rs
+++ b/core/src/network/api.rs
@@ -30,6 +30,12 @@ impl Api {
         api.backend.init(token).await
     }
 
+    pub async fn close() -> Result<()> {
+        let api = Self::get_instance();
+
+        api.backend.close().await
+    }
+
     pub async fn get_player(id: &Id) -> Result<Player> {
         let api = Self::get_instance();
 
@@ -42,10 +48,10 @@ impl Api {
         api.backend.get_lobby(id).await
     }
 
-    pub fn next_event() -> Option<NetworkEvent> {
+    pub fn poll_events() -> Vec<NetworkEvent> {
         let api = Self::get_instance();
 
-        api.backend.next_event()
+        api.backend.poll_events()
     }
 }
 
@@ -54,12 +60,14 @@ impl Api {
 pub trait ApiBackend {
     /// Init backend
     async fn init(&mut self, token: &str) -> Result<()>;
+    /// Close connection
+    async fn close(&mut self) -> Result<()>;
     /// Get `Player` with the specified `id`
     async fn get_player(&mut self, id: &Id) -> Result<Player>;
     /// Get `Lobby` with the specified `id`
     async fn get_lobby(&mut self, id: &Id) -> Result<Lobby>;
     /// Get the next event in the event queue
-    fn next_event(&mut self) -> Option<NetworkEvent>;
+    fn poll_events(&mut self) -> Vec<NetworkEvent>;
 }
 
 /// This is used as a placeholder for when no external backend implementation is available.
@@ -103,6 +111,10 @@ impl ApiBackend for MockApiBackend {
         Ok(())
     }
 
+    async fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn get_player(&mut self, id: &Id) -> Result<Player> {
         if let Some(player) = self.players.iter().find(|&player| player.id == *id) {
             Ok(player.clone())
@@ -119,7 +131,7 @@ impl ApiBackend for MockApiBackend {
         }
     }
 
-    fn next_event(&mut self) -> Option<NetworkEvent> {
-        None
+    fn poll_events(&mut self) -> Vec<NetworkEvent> {
+        Vec::new()
     }
 }

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -1,0 +1,34 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::network::{Lobby, Protocol};
+use crate::Id;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum NetworkEvent {
+    LobbyCreated {
+        lobby_id: Id,
+    },
+    LobbyChanged {
+        lobby: Lobby,
+    },
+    PlayerJoined {
+        player_id: Id,
+        username: String,
+        port: u16,
+        protocol: Protocol,
+    },
+    PlayerLeft {
+        player_id: Id,
+    },
+    PlayerReconnecting {
+        player_id: Id,
+        protocol: Protocol,
+    },
+    GameStarted {
+        lobby_id: Id,
+    },
+    GameEnded {
+        lobby_id: Id,
+    },
+}

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::network::{Lobby, Protocol};
+use crate::network::Lobby;
 use crate::Id;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -12,18 +12,22 @@ pub enum NetworkEvent {
     LobbyChanged {
         lobby: Lobby,
     },
+    MarkPlayerReady {
+        player_id: Id,
+    },
+    MarkPlayerNotReady {
+        player_id: Id,
+    },
     PlayerJoined {
         player_id: Id,
         username: String,
         port: u16,
-        protocol: Protocol,
     },
     PlayerLeft {
         player_id: Id,
     },
     PlayerReconnecting {
         player_id: Id,
-        protocol: Protocol,
     },
     GameStarted {
         lobby_id: Id,

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -12,10 +12,10 @@ pub enum NetworkEvent {
     LobbyChanged {
         lobby: Lobby,
     },
-    MarkPlayerReady {
+    PlayerMarkedReady {
         player_id: Id,
     },
-    MarkPlayerNotReady {
+    PlayerMarkedNotReady {
         player_id: Id,
     },
     PlayerJoined {

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -1,7 +1,9 @@
 mod api;
+mod event;
 mod status;
 
 pub use api::{Api, ApiBackend, MockApiBackend};
+pub use event::NetworkEvent;
 pub use status::RequestStatus;
 
 use std::net::SocketAddr;
@@ -12,6 +14,14 @@ use crate::Id;
 
 pub const DEFAULT_PORT: u16 = 9000;
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde_json", serde(rename_all = "snake_case"))]
+pub enum Protocol {
+    Udp,
+    Tcp,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Server {
@@ -20,7 +30,7 @@ pub struct Server {
     pub tcp: SocketAddr,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde_json", serde(rename_all = "snake_case"))]
 pub enum LobbyPrivacy {
@@ -45,7 +55,6 @@ pub struct Lobby {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde_json", serde(rename_all = "snake_case"))]
 pub enum LobbyState {
     NotStarted,
     LobbyReady,
@@ -60,7 +69,7 @@ pub enum LobbyState {
 pub struct Player {
     pub id: Id,
     pub username: String,
-    pub state: Vec<ClientState>,
+    pub state: ClientState,
 }
 
 impl Player {
@@ -68,15 +77,15 @@ impl Player {
         Player {
             id: id.clone(),
             username: username.to_string(),
-            state: Vec::new(),
+            state: ClientState::None,
         }
     }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde_json", serde(rename_all = "snake_case"))]
 pub enum ClientState {
+    None,
     Joined,
     Ready,
     Playing,

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -14,14 +14,6 @@ use crate::Id;
 
 pub const DEFAULT_PORT: u16 = 9000;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde_json", serde(rename_all = "snake_case"))]
-pub enum Protocol {
-    Udp,
-    Tcp,
-}
-
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Server {

--- a/mods/active_mods.json
+++ b/mods/active_mods.json
@@ -1,0 +1,4 @@
+[
+  "test_mod_one",
+  "test_mod_two"
+]

--- a/mods/test_mod_one/fishfight_mod.json
+++ b/mods/test_mod_one/fishfight_mod.json
@@ -1,0 +1,7 @@
+{
+  "id": "test_mod_one",
+  "name": "Test Mod One",
+  "description": "This is a mod meant for testing",
+  "version": "0.1.0",
+  "kind": "data_only"
+}

--- a/mods/test_mod_two/fishfight_mod.json
+++ b/mods/test_mod_two/fishfight_mod.json
@@ -1,0 +1,13 @@
+{
+  "id": "test_mod_two",
+  "name": "Test Mod Two",
+  "description": "This is another mod meant for testing",
+  "version": "0.1.0",
+  "kind": "data_only",
+  "dependencies": [
+    {
+      "id": "test_mod_one",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/src/editor/gui/windows/create_map.rs
+++ b/src/editor/gui/windows/create_map.rs
@@ -11,7 +11,7 @@ use core::text::ToStringHelper;
 use super::{ButtonParams, EditorAction, EditorContext, Window, WindowParams};
 
 use crate::map::Map;
-use crate::resources::map_name_to_filename;
+use crate::resources::{map_name_to_filename, MAP_EXPORTS_DEFAULT_DIR, MAP_EXPORTS_EXTENSION};
 use crate::Resources;
 
 pub struct CreateMapWindow {
@@ -33,7 +33,7 @@ impl CreateMapWindow {
 
         let map_export_path = {
             let resources = storage::get::<Resources>();
-            Path::new(&resources.assets_dir).join(Resources::MAP_EXPORTS_DEFAULT_DIR)
+            Path::new(&resources.assets_dir).join(MAP_EXPORTS_DEFAULT_DIR)
         };
 
         CreateMapWindow {
@@ -77,7 +77,7 @@ impl Window for CreateMapWindow {
         {
             let path_label = Path::new(&self.map_export_path)
                 .join(map_name_to_filename(&self.name))
-                .with_extension(Resources::MAP_EXPORTS_EXTENSION);
+                .with_extension(MAP_EXPORTS_EXTENSION);
 
             widgets::Label::new(path_label.to_string_lossy().as_ref()).ui(ui);
         }

--- a/src/editor/gui/windows/save_map.rs
+++ b/src/editor/gui/windows/save_map.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 use crate::map::Map;
 
 use super::{ButtonParams, EditorAction, EditorContext, Window, WindowParams};
-use crate::resources::{is_valid_map_export_path, map_name_to_filename};
+use crate::resources::{
+    is_valid_map_export_path, map_name_to_filename, MAP_EXPORTS_DEFAULT_DIR, MAP_EXPORTS_EXTENSION,
+};
 use crate::Resources;
 
 pub struct SaveMapWindow {
@@ -59,9 +61,9 @@ impl Window for SaveMapWindow {
             {
                 let resources = storage::get::<Resources>();
                 let path = Path::new(&resources.assets_dir)
-                    .join(Resources::MAP_EXPORTS_DEFAULT_DIR)
+                    .join(MAP_EXPORTS_DEFAULT_DIR)
                     .join(map_name_to_filename(&self.name))
-                    .with_extension(Resources::MAP_EXPORTS_EXTENSION);
+                    .with_extension(MAP_EXPORTS_EXTENSION);
 
                 widgets::Label::new(path.to_string_lossy().as_ref()).ui(ui);
             }
@@ -82,9 +84,9 @@ impl Window for SaveMapWindow {
     fn get_buttons(&self, _map: &Map, _ctx: &EditorContext) -> Vec<ButtonParams> {
         let mut res = Vec::new();
 
-        let path = Path::new(Resources::MAP_EXPORTS_DEFAULT_DIR)
+        let path = Path::new(MAP_EXPORTS_DEFAULT_DIR)
             .join(map_name_to_filename(&self.name))
-            .with_extension(Resources::MAP_EXPORTS_EXTENSION);
+            .with_extension(MAP_EXPORTS_EXTENSION);
 
         let mut action = None;
         if is_valid_map_export_path(&path, self.should_overwrite) {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -64,7 +64,9 @@ use macroquad::{
 use core::text::{draw_aligned_text, HorizontalAlignment, VerticalAlignment};
 
 use super::map::{Map, MapLayerKind};
-use crate::resources::{map_name_to_filename, MapResource};
+use crate::resources::{
+    map_name_to_filename, MapResource, MAP_EXPORTS_DEFAULT_DIR, MAP_EXPORTS_EXTENSION,
+};
 
 #[derive(Debug, Clone)]
 pub struct EditorContext {
@@ -616,9 +618,9 @@ impl Editor {
                 let mut map_resource = self.map_resource.clone();
 
                 if let Some(name) = name {
-                    let path = Path::new(Resources::MAP_EXPORTS_DEFAULT_DIR)
+                    let path = Path::new(MAP_EXPORTS_DEFAULT_DIR)
                         .join(map_name_to_filename(&name))
-                        .with_extension(Resources::MAP_EXPORTS_EXTENSION);
+                        .with_extension(MAP_EXPORTS_EXTENSION);
 
                     map_resource.meta.name = name;
                     map_resource.meta.path = path.to_string_lossy().to_string();

--- a/src/gui/create_map.rs
+++ b/src/gui/create_map.rs
@@ -11,7 +11,9 @@ use core::Result;
 use super::{GuiResources, Panel};
 
 use crate::gui::draw_main_menu_background;
-use crate::resources::{map_name_to_filename, MapResource, Resources};
+use crate::resources::{
+    map_name_to_filename, MapResource, Resources, MAP_EXPORTS_DEFAULT_DIR, MAP_EXPORTS_EXTENSION,
+};
 use crate::{is_gamepad_btn_pressed, GamepadContext};
 
 enum WindowState {
@@ -43,7 +45,7 @@ pub async fn show_create_map_menu() -> Result<Option<MapResource>> {
 
     let map_export_path = {
         let resources = storage::get::<Resources>();
-        Path::new(&resources.assets_dir).join(Resources::MAP_EXPORTS_DEFAULT_DIR)
+        Path::new(&resources.assets_dir).join(MAP_EXPORTS_DEFAULT_DIR)
     };
 
     let mut gamepad_system = storage::get_mut::<GamepadContext>();
@@ -70,7 +72,7 @@ pub async fn show_create_map_menu() -> Result<Option<MapResource>> {
                 {
                     let path_label = map_export_path
                         .join(map_name_to_filename(&name))
-                        .with_extension(Resources::MAP_EXPORTS_EXTENSION);
+                        .with_extension(MAP_EXPORTS_EXTENSION);
 
                     widgets::Label::new(path_label.to_string_lossy().as_ref()).ui(ui);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ pub use ecs::Owner;
 
 use crate::effects::passive::init_passive_effects;
 use crate::game::GameMode;
-use crate::network::init_api;
 use crate::particles::Particles;
 use crate::resources::load_resources;
 pub use effects::{
@@ -66,10 +65,11 @@ pub use effects::{
 
 pub type CollisionWorld = macroquad_platformer::World;
 
-const ASSETS_DIR_ENV_VAR: &str = "FISHFIGHT_ASSETS";
 const CONFIG_FILE_ENV_VAR: &str = "FISHFIGHT_CONFIG";
+const ASSETS_DIR_ENV_VAR: &str = "FISHFIGHT_ASSETS";
+const MODS_DIR_ENV_VAR: &str = "FISHFIGHT_MODS";
 
-const WINDOW_TITLE: &str = "FishFight";
+const WINDOW_TITLE: &str = "Fish Fight";
 
 /// Exit to main menu
 pub fn exit_to_main_menu() {
@@ -117,10 +117,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     use gui::MainMenuResult;
 
     let assets_dir = env::var(ASSETS_DIR_ENV_VAR).unwrap_or_else(|_| "./assets".to_string());
+    let mods_dir = env::var(MODS_DIR_ENV_VAR).unwrap_or_else(|_| "./mods".to_string());
 
     rand::srand(0);
 
-    load_resources(&assets_dir).await?;
+    load_resources(&assets_dir, &mods_dir).await?;
 
     {
         let gamepad_system = fishsticks::GamepadContext::init().unwrap();
@@ -134,7 +135,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     init_passive_effects();
 
-    init_api("player_one_token").await?;
+    // init_api("player_one_token").await?;
 
     'outer: loop {
         match gui::show_main_menu().await {
@@ -202,7 +203,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 match event {
                     ApplicationEvent::ReloadResources => {
                         let resources = storage::get::<Resources>();
-                        load_resources(&resources.assets_dir).await?;
+                        load_resources(&resources.assets_dir, &resources.mods_dir).await?;
                     }
                     ApplicationEvent::MainMenu => break 'inner,
                     ApplicationEvent::Quit => break 'outer,
@@ -221,6 +222,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
         stop_music();
     }
+
+    // Api::close().await?;
 
     Ok(())
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -5,17 +5,16 @@ use hecs::World;
 use core::network::Api;
 use core::Result;
 
+#[cfg(feature = "ultimate")]
 pub async fn init_api(token: &str) -> Result<()> {
-    #[cfg(feature = "ultimate")]
-    Api::init::<ultimate::UltimateApiBackend>(token).await?;
-
-    #[cfg(not(feature = "ultimate"))]
-    Api::init::<core::network::MockApiBackend>(token).await?;
-
-    Ok(())
+    Api::init::<ultimate::UltimateApiBackend>(token).await
 }
 
-#[allow(dead_code)]
+#[cfg(not(feature = "ultimate"))]
+pub async fn init_api(token: &str) -> Result<()> {
+    Api::init::<core::network::MockApiBackend>(token).await
+}
+
 #[derive(Default)]
 pub struct NetworkClient {}
 
@@ -25,11 +24,12 @@ impl NetworkClient {
     }
 }
 
-pub fn update_network_client(_world: &mut World) {}
+pub fn update_network_client(_world: &mut World) {
+    for _event in Api::poll_events() {}
+}
 
 pub fn fixed_update_network_client(_world: &mut World) {}
 
-#[allow(dead_code)]
 #[derive(Default)]
 pub struct NetworkHost {}
 
@@ -39,6 +39,8 @@ impl NetworkHost {
     }
 }
 
-pub fn update_network_host(_world: &mut World) {}
+pub fn update_network_host(_world: &mut World) {
+    for _event in Api::poll_events() {}
+}
 
 pub fn fixed_update_network_host(_world: &mut World) {}


### PR DESCRIPTION
This PR adds mods to Fish Fight.

Currently, only data mods are allowed and they will currently **extend** the core resources (in the future we will add a replace option, for when creating total conversion mods). This means that a mods resources will be added to `Resources`, or overwrite existing resources, if ids are the same.

The `mods` directory holds two example mods that show how to create a mod and how dependencies work. These examples hold no actual content but this is added just like when adding to the `assets` dir, using the same resource file names and the same folder.

Mods are loaded in order, according to the order given in `active_mods.json`

All resources that are loaded dynamically are supported in mods:

- decoration (`decoration.json`)
- images (`images.json`)
- items (`items.json`)
- maps (`maps.json`)
- music (`music.json`)
- particle effects (`particle_effects.json`)
- player characters (`player_characters.json`)
- sounds (`sounds.json`)
- textures (`textures.json`)