### PR TITLE
Store player characters in a hash map in stead of a vec

### DIFF
--- a/src/gui/main_menu.rs
+++ b/src/gui/main_menu.rs
@@ -74,9 +74,17 @@ fn build_main_menu() -> Menu {
                 title: "Local Game".to_string(),
                 ..Default::default()
             },
+            #[cfg(debug_assertions)]
             MenuEntry {
                 index: ROOT_OPTION_NETWORK_GAME,
                 title: "Network Game".to_string(),
+                ..Default::default()
+            },
+            #[cfg(not(debug_assertions))]
+            MenuEntry {
+                index: ROOT_OPTION_NETWORK_GAME,
+                title: "Network Game".to_string(),
+                is_disabled: true,
                 ..Default::default()
             },
             MenuEntry {
@@ -359,12 +367,12 @@ fn network_game_ui(ui: &mut ui::Ui, _state: &mut NetworkUiState) -> Option<MainM
                 PlayerParams {
                     index: 0,
                     controller: PlayerControllerKind::LocalInput(GameInputScheme::KeyboardLeft),
-                    character: resources.player_characters[0].clone(),
+                    character: resources.player_characters.get("pescy").cloned().unwrap(),
                 },
                 PlayerParams {
                     index: 1,
                     controller: PlayerControllerKind::Network(Id::from("2")),
-                    character: resources.player_characters[1].clone(),
+                    character: resources.player_characters.get("sharky").cloned().unwrap(),
                 },
             ],
         });
@@ -380,12 +388,12 @@ fn network_game_ui(ui: &mut ui::Ui, _state: &mut NetworkUiState) -> Option<MainM
                 PlayerParams {
                     index: 0,
                     controller: PlayerControllerKind::Network(Id::from("1")),
-                    character: resources.player_characters[0].clone(),
+                    character: resources.player_characters.get("pescy").cloned().unwrap(),
                 },
                 PlayerParams {
                     index: 1,
                     controller: PlayerControllerKind::LocalInput(GameInputScheme::KeyboardLeft),
-                    character: resources.player_characters[1].clone(),
+                    character: resources.player_characters.get("sharky").cloned().unwrap(),
                 },
             ],
         });

--- a/src/gui/select_character.rs
+++ b/src/gui/select_character.rs
@@ -34,7 +34,11 @@ pub async fn show_select_characters_menu(
 
     let player_characters = {
         let resources = storage::get::<Resources>();
-        resources.player_characters.clone()
+        resources
+            .player_characters
+            .values()
+            .cloned()
+            .collect::<Vec<_>>()
     };
 
     assert!(

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -326,21 +326,19 @@ async fn load_resources_from<P: AsRef<Path>>(path: P, resources: &mut Resources)
         }
     }
 
-    let player_characters: Vec<PlayerCharacterMetadata> = {
+    {
         let path = path
             .join(PLAYER_CHARACTERS_FILE)
             .with_extension(RESOURCE_FILES_EXTENSION);
 
         if let Ok(bytes) = load_file(&path.to_string_helper()).await {
-            deserialize_json_bytes(&bytes)?
-        } else {
-            Vec::new()
+            let metadata: Vec<PlayerCharacterMetadata> = deserialize_json_bytes(&bytes)?;
+
+            for meta in metadata {
+                resources.player_characters.insert(meta.id.clone(), meta);
+            }
         }
     };
-
-    for character in player_characters {
-        resources.player_characters.push(character);
-    }
 
     Ok(())
 }
@@ -359,7 +357,7 @@ pub struct Resources {
     pub maps: Vec<MapResource>,
     pub decoration: HashMap<String, DecorationMetadata>,
     pub items: HashMap<String, MapItemMetadata>,
-    pub player_characters: Vec<PlayerCharacterMetadata>,
+    pub player_characters: HashMap<String, PlayerCharacterMetadata>,
 }
 
 impl Resources {
@@ -379,7 +377,7 @@ impl Resources {
             images: HashMap::new(),
             maps: Vec::new(),
             items: HashMap::new(),
-            player_characters: Vec::new(),
+            player_characters: HashMap::new(),
         };
 
         load_resources_from(assets_dir, &mut resources).await?;


### PR DESCRIPTION
This stores player characters in a map in stead of a vec (in `Resources`), so that it is more consistent with the other resources (and allows overwriting in mods).

It also disables the network game button in main menu for release builds (as networking makes the game crash to desktop atm)