### PR TITLE
Include mods folder in release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           cp target/${{ matrix.config.target }}/release/fishfight.exe $release_dir/
           strip $release_dir/fishfight.exe
           find assets -name "*.schema.json" -exec rm -f {} \;
-          cp -R assets/ $release_dir/
+          cp -R assets/ mods/ $release_dir/
           7z a -tzip $artifact_path $release_dir/
 
       - name: Prepare artifacts [Unix]
@@ -87,7 +87,7 @@ jobs:
           cp target/${{ matrix.config.target }}/release/fishfight $release_dir/
           strip $release_dir/fishfight || true
           find assets -name "*.schema.json" -exec rm -f {} \;
-          cp -R assets $release_dir
+          cp -R assets mods $release_dir
           tar -czvf $artifact_path $release_dir/
 
       - name: Deploy | Upload artifacts


### PR DESCRIPTION
This PR updates the release workflow to include `mods/` folder in resulting archives.
