### PR TITLE
Use the package version as game version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,6 @@ pub use effects::{
 
 pub type CollisionWorld = macroquad_platformer::World;
 
-pub const GAME_VERSION: &str = "0.4.1";
-
 const CONFIG_FILE_ENV_VAR: &str = "FISHFIGHT_CONFIG";
 const ASSETS_DIR_ENV_VAR: &str = "FISHFIGHT_ASSETS";
 const MODS_DIR_ENV_VAR: &str = "FISHFIGHT_MODS";

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -19,7 +19,7 @@ use crate::gui::GuiResources;
 use crate::map::DecorationMetadata;
 
 use crate::player::PlayerCharacterMetadata;
-use crate::{items::MapItemMetadata, map::Map, GAME_VERSION};
+use crate::{items::MapItemMetadata, map::Map};
 
 const PARTICLE_EFFECTS_DIR: &str = "particle_effects";
 const SOUNDS_FILE: &str = "sounds";
@@ -633,7 +633,7 @@ async fn load_mods<P: AsRef<Path>>(mods_dir: P, resources: &mut Resources) -> Re
         let mut has_game_version_mismatch = false;
 
         if let Some(req_version) = &meta.game_version {
-            if *req_version != GAME_VERSION {
+            if *req_version != env!("CARGO_PKG_VERSION") {
                 has_game_version_mismatch = true;
 
                 #[cfg(debug_assertions)]


### PR DESCRIPTION
This PR removes `GAME_VERSION` constant and uses `env!("CARGO_PKG_VERSION")` for comparing the current version of the game with the required version.
