### PR TITLE
Include SDL2 in Windows binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,13 @@ jobs:
         shell: bash
         if: matrix.config.os == 'windows-latest'
         run: |
+          if [ "${{ matrix.config.target }}" = "x86_64-pc-windows-msvc" ]; then
+            arch="win32-x64"
+          else
+            arch="win32-x86"
+          fi
+          sdl2_download_url=$(curl 'https://api.github.com/repos/libsdl-org/SDL/releases' | \
+            jq -r ".[0].assets[] | select(.name | contains (\"$arch\")).browser_download_url")
           release_dir="fishfight-${{ env.RELEASE_VERSION }}"
           artifact_path="fishfight-${{ env.RELEASE_VERSION }}-${{ matrix.config.target }}.zip"
           echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
@@ -74,6 +81,7 @@ jobs:
           strip $release_dir/fishfight.exe
           find assets -name "*.schema.json" -exec rm -f {} \;
           cp -R assets/ mods/ $release_dir/
+          curl -L --output "SDL2-$arch.zip" $sdl2_download_url && unzip "SDL2-$arch.zip" -d $release_dir/
           7z a -tzip $artifact_path $release_dir/
 
       - name: Prepare artifacts [Unix]


### PR DESCRIPTION
This PR updates release workflow to include SDL2 in Windows releases.

See: https://github.com/fishfight/FishLauncher/issues/6