### PR TITLE
Update PACKAGING.md about build dependencies

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -5,12 +5,9 @@
 #### Build dependencies
 
 - [Rust](https://www.rust-lang.org/tools/install) (`1.53.0+`)
-- [CMake](https://cmake.org/download/) (only needed if `bundled-sdl2` feature is **enabled** in [Cargo.toml](./Cargo.toml))
-- [SDL2](https://www.libsdl.org/download-2.0.php) (only needed if `bundled-sdl2` feature is **disabled** in [Cargo.toml](./Cargo.toml))
+- [libudev](https://www.freedesktop.org/software/systemd/man/libudev.html)
 
 #### Runtime dependencies
-
-##### Linux
 
 - [libX11](https://gitlab.freedesktop.org/xorg/lib/libx11)
 - [libXi](https://gitlab.freedesktop.org/xorg/lib/libxi)
@@ -30,7 +27,7 @@ cargo run --release --locked
 
 - `FISHFIGHT_CONFIG`: configuration file (default: `config.json`)
 - `FISHFIGHT_ASSETS`: assets directory (default: `assets/`)
-- `FISHFIGHT_MODS`:  mods directory (default: `mods/`)
+- `FISHFIGHT_MODS`: mods directory (default: `mods/`)
 
 ### Package
 


### PR DESCRIPTION
SDL2 is removed and `libudev` is required for building FF now.