### PR TITLE
Add WindowConfig type to Config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,11 +1,10 @@
-fullscreen = false
-high_dpi = false
-
-[resolution]
+[window]
 width = 955
 height = 600
+fullscreen = false
+high-dpi = false
 
-[input_mapping.keyboard_primary]
+[input.keyboard-primary]
 left = 'Left'
 right = 'Right'
 fire = 'L'
@@ -14,7 +13,7 @@ pickup = 'K'
 crouch = 'Down'
 slide = 'RightControl'
 
-[input_mapping.keyboard_secondary]
+[input.keyboard-secondary]
 left = 'A'
 right = 'D'
 fire = 'V'
@@ -23,7 +22,7 @@ pickup = 'C'
 crouch = 'S'
 slide = 'F'
 
-[[input_mapping.gamepads]]
+[[input.gamepads]]
 id = 0
 fire = 'A'
 jump = 'X'

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ macroquad = { version = "0.3.10" }
 hecs = "0.7.1"
 serde = { version = "1.0", package = "serde", features = ["derive"] }
 serde_json = { version = "1.0" }
-toml = "0.5.8"
+toml = "0.5"
 async-trait = "0.1.52"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -9,13 +9,9 @@ use crate::Result;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
     #[serde(default)]
-    pub fullscreen: bool,
+    pub window: WindowConfig,
     #[serde(default)]
-    pub high_dpi: bool,
-    #[serde(default)]
-    pub resolution: Resolution,
-    #[serde(default)]
-    pub input_mapping: InputMapping,
+    pub input: InputMapping,
 }
 
 impl Config {
@@ -23,29 +19,35 @@ impl Config {
         let path = path.as_ref();
 
         let mut res = if path.exists() {
-            let file_contents = fs::read_to_string(path)?;
-            serde_json::from_str(&file_contents)?
+            let bytes = fs::read(path)?;
+            toml::from_slice(&bytes)?
         } else {
             Config::default()
         };
 
-        res.input_mapping.verify()?;
+        res.input.verify()?;
 
         Ok(res)
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Resolution {
-    pub width: i32,
-    pub height: i32,
+pub struct WindowConfig {
+    pub width: u32,
+    pub height: u32,
+    #[serde(default, rename = "fullscreen")]
+    pub is_fullscreen: bool,
+    #[serde(default, rename = "high-dpi")]
+    pub is_high_dpi: bool,
 }
 
-impl Default for Resolution {
+impl Default for WindowConfig {
     fn default() -> Self {
-        Resolution {
+        WindowConfig {
             width: 955,
             height: 600,
+            is_fullscreen: false,
+            is_high_dpi: false,
         }
     }
 }

--- a/core/src/input/mapping.rs
+++ b/core/src/input/mapping.rs
@@ -533,9 +533,15 @@ impl From<&GamepadId> for GamepadMapping {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InputMapping {
-    #[serde(default = "KeyboardMapping::default_primary")]
+    #[serde(
+        default = "KeyboardMapping::default_primary",
+        rename = "keyboard-primary"
+    )]
     pub keyboard_primary: KeyboardMapping,
-    #[serde(default = "KeyboardMapping::default_secondary")]
+    #[serde(
+        default = "KeyboardMapping::default_secondary",
+        rename = "keyboard-secondary"
+    )]
     pub keyboard_secondary: KeyboardMapping,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gamepads: Vec<GamepadMapping>,

--- a/core/src/input/mod.rs
+++ b/core/src/input/mod.rs
@@ -76,7 +76,7 @@ pub fn collect_local_input(input_scheme: GameInputScheme) -> PlayerInput {
             let input_mapping = {
                 let config = storage::get::<Config>();
                 config
-                    .input_mapping
+                    .input
                     .get_gamepad_mapping(ix.into())
                     .unwrap_or_else(|| ix.into())
             };
@@ -110,9 +110,9 @@ pub fn collect_local_input(input_scheme: GameInputScheme) -> PlayerInput {
             let config = storage::get::<Config>();
 
             if matches!(input_scheme, GameInputScheme::KeyboardRight) {
-                config.input_mapping.keyboard_primary.clone()
+                config.input.keyboard_primary.clone()
             } else {
-                config.input_mapping.keyboard_secondary.clone()
+                config.input.keyboard_secondary.clone()
             }
         };
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,7 @@ mod channel;
 mod transform;
 
 pub use channel::Channel;
-pub use config::{Config, Resolution};
+pub use config::{Config, WindowConfig};
 pub use error::{Error, Result};
 pub use transform::Transform;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,10 +94,10 @@ fn window_conf() -> Conf {
 
     Conf {
         window_title: WINDOW_TITLE.to_owned(),
-        high_dpi: config.high_dpi,
-        fullscreen: config.fullscreen,
-        window_width: config.resolution.width,
-        window_height: config.resolution.height,
+        high_dpi: config.window.is_high_dpi,
+        fullscreen: config.window.is_fullscreen,
+        window_width: config.window.width as i32,
+        window_height: config.window.height as i32,
         ..Default::default()
     }
 }


### PR DESCRIPTION
This removes the `Resolution` type and add its members, as well as other window-related stuff, to a new `WindowConfig` type