### PR TITLE
Disable debug builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           - { os: macos-latest, target: "aarch64-apple-darwin" }
           - { os: windows-latest, target: "x86_64-pc-windows-msvc" }
           - { os: windows-latest, target: "i686-pc-windows-msvc" }
-        profile: ["", --release]
+        profile: ["--release"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR disables debug mode builds until `windows-latest` runners are stable again.