### PR TITLE
Update fishsticks dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "fishsticks"
-version = "0.2.0"
-source = "git+https://github.com/fishfight/fishsticks#95b45b717e427fb5fa1671f3bdf686d7270ad8a1"
+version = "0.2.1"
+source = "git+https://github.com/fishfight/fishsticks#ffd11a5b48abecadf8cd47033b1b26fff74b5557"
 dependencies = [
  "cfg-if",
  "gilrs",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-fishsticks = { git = "https://github.com/fishfight/fishsticks", default-features = false, features = ["gilrs"] }
+fishsticks = { version = "0.2.1", git = "https://github.com/fishfight/fishsticks", default-features = false, features = ["gilrs"] }
 macroquad = { version = "0.3.10" }
 hecs = "0.7.1"
 serde = { version = "1.0", package = "serde", features = ["derive"] }

--- a/core/src/input/mapping.rs
+++ b/core/src/input/mapping.rs
@@ -526,7 +526,7 @@ impl From<usize> for GamepadMapping {
 
 impl From<&GamepadId> for GamepadMapping {
     fn from(id: &GamepadId) -> Self {
-        let id: usize = id.into();
+        let id: usize = (*id).into();
         id.into()
     }
 }

--- a/core/src/input/mod.rs
+++ b/core/src/input/mod.rs
@@ -77,7 +77,7 @@ pub fn collect_local_input(input_scheme: GameInputScheme) -> PlayerInput {
                 let config = storage::get::<Config>();
                 config
                     .input
-                    .get_gamepad_mapping(ix.into())
+                    .get_gamepad_mapping((*ix).into())
                     .unwrap_or_else(|| ix.into())
             };
 


### PR DESCRIPTION
This PR updates [fishsticks](https://github.com/fishfight/fishsticks) dependency to the latest version (`0.2.1`) and fixes the compilation errors that occurred due to this change.
