### PR TITLE
Fix Reload Resources Button

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,6 @@ async fn init_game() -> Result<bool> {
         }
         MainMenuResult::ReloadResources => {
             reload_resources();
-            return Ok(true);
         }
         MainMenuResult::Credits => {
             let resources = storage::get::<Resources>();
@@ -233,6 +232,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 match event {
                     ApplicationEvent::ReloadResources => {
                         load_resources(&assets_dir, &mods_dir).await?;
+                        break 'inner;
                     }
                     ApplicationEvent::MainMenu => break 'inner,
                     ApplicationEvent::Quit => break 'outer,


### PR DESCRIPTION
Avoid entering an endless loop when clicking the "Reload Resources" button.

Eventually we might want a progress bar or something, because the UI will freeze while the assets are being loaded, but that's not a big deal and not something that needs to be done now.