### PR TITLE
Switch to Rust nightly for builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
           profile: minimal
           target: ${{ matrix.config.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
           profile: minimal
           target: ${{ matrix.config.target }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Build is failing on the `main` branch due to https://github.com/rust-lang/rust/issues/93706

```
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
  --> core/src/math/size.rs:16:6
   |
16 | impl<T: Num + Copy> Size<T> {
   |      ^
17 |     pub const fn new(width: T, height: T) -> Self {
   |     --------------------------------------------- function declared as const here
   |
   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `fishfight-core` due to previous error
Error: Process completed with exit code 101.
```

This PR updates the workflows and adds a Rust toolchain configuration to use nightly channel until `const_fn_trait_bound` is available in stable Rust.

