### PR TITLE
Kill Fish When They Fall Out of Bounds

### DIFF
--- a/src/game/camera.rs
+++ b/src/game/camera.rs
@@ -1,7 +1,10 @@
+use macroquad::prelude::collections::storage;
 use macroquad::prelude::*;
 use macroquad::rand::gen_range;
 
 use core::noise::NoiseGenerator;
+
+use crate::map::Map;
 
 struct Shake {
     direction: (f32, f32),
@@ -49,7 +52,25 @@ impl GameCamera {
     }
 
     pub fn add_player_rect(&mut self, rect: Rect) {
-        self.player_rects.push(rect);
+        let map = storage::get::<Map>();
+        let playable = map.get_playable_area();
+        if playable.overlaps(&rect) {
+            self.player_rects.push(rect);
+
+        // We don't want to try to follow the player out of the playable area, so set the
+        // effective player rect to the closest spot to the player that is still touching the
+        // playable area.
+        } else {
+            let min = Vec2::new(playable.x, playable.y);
+            let max = min + Vec2::new(playable.w, playable.h);
+
+            self.player_rects.push(Rect::new(
+                rect.x.max(min.x).min(max.x),
+                rect.y.max(min.y).min(max.y),
+                rect.w,
+                rect.h,
+            ));
+        }
     }
 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -36,7 +36,7 @@ use crate::effects::active::triggered::{fixed_update_triggered_effects, update_t
 use crate::items::spawn_item;
 use crate::map::{
     debug_draw_fish_schools, fixed_update_sproingers, spawn_crab, spawn_decoration,
-    spawn_fish_school, spawn_sproinger, update_crabs, update_fish_schools,
+    spawn_fish_school, spawn_sproinger, update_crabs, update_fish_schools, update_map_kill_zone,
 };
 use crate::network::{
     fixed_update_network_client, fixed_update_network_host, update_network_client,
@@ -118,6 +118,7 @@ impl Game {
 
         if matches!(mode, GameMode::Local | GameMode::NetworkHost) {
             updates_builder
+                .add_system(update_map_kill_zone)
                 .add_system(update_player_states)
                 .add_system(update_player_inventory)
                 .add_system(update_player_passive_effects)

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -7,11 +7,13 @@ use serde::{Deserialize, Serialize};
 mod crab;
 mod decoration;
 mod fish_school;
+mod player_interaction;
 mod sproinger;
 
 pub use crab::*;
 pub use decoration::*;
 pub use fish_school::*;
+pub use player_interaction::*;
 pub use sproinger::*;
 
 use core::math::URect;
@@ -23,6 +25,10 @@ use crate::{
     json::{self, TiledMap},
     Resources,
 };
+
+/// The ammount of space above the map that the player can be without being killed
+const EXTRA_PLAYABLE_SKY: f32 = 200.0;
+const EXTRA_PLAYABLE_WIDTH: f32 = 400.0;
 
 pub type MapProperty = core::json::GenericParam;
 
@@ -113,6 +119,19 @@ impl Map {
         vec2(
             self.grid_size.x as f32 * self.tile_size.x,
             self.grid_size.y as f32 * self.tile_size.y,
+        )
+    }
+
+    /// Get the playable map area.
+    ///
+    /// Any player that doesn't overlap the play area will be killed.
+    pub fn get_playable_area(&self) -> Rect {
+        let size = self.get_size();
+        Rect::new(
+            self.world_offset.x - EXTRA_PLAYABLE_WIDTH / 2.0,
+            self.world_offset.y - EXTRA_PLAYABLE_SKY,
+            size.x + EXTRA_PLAYABLE_WIDTH,
+            size.y + EXTRA_PLAYABLE_SKY,
         )
     }
 

--- a/src/map/player_interaction.rs
+++ b/src/map/player_interaction.rs
@@ -1,0 +1,30 @@
+use core::Transform;
+
+use hecs::World;
+use macroquad::prelude::collections::storage;
+
+use crate::{
+    player::{Player, PlayerState},
+    PhysicsBody,
+};
+
+use super::Map;
+
+pub fn update_map_kill_zone(world: &mut World) {
+    let map = storage::get::<Map>();
+
+    for (_, (player, transform, body)) in world
+        .query::<(&mut Player, &Transform, &PhysicsBody)>()
+        .iter()
+    {
+        let player: &mut Player = player;
+        let transform: &Transform = transform;
+        let body: &PhysicsBody = body;
+
+        let player_rect = body.as_rect(transform.position);
+
+        if !map.get_playable_area().overlaps(&player_rect) {
+            player.state = PlayerState::Dead;
+        }
+    }
+}


### PR DESCRIPTION
This fixes the issue where, on levels that you can fall off of, the fish falls off and continues falling forever without dying.

Also, it addresses the issue where the camera try to adjust to follow the falling fish outside of the play area, causing issues with parallax backgrounds.

**Before:**
![Peek 2022-05-23 14-20](https://user-images.githubusercontent.com/25393315/169891324-72612271-db59-4318-a3fc-f52bc24e0ac0.gif)


**After:**
![Peek 2022-05-23 14-19](https://user-images.githubusercontent.com/25393315/169891308-85d7830a-1ba3-4939-bf8a-fa674d3ba56b.gif)
