### PR TITLE
Increase Jump Force

### DIFF
--- a/src/player/character.rs
+++ b/src/player/character.rs
@@ -86,7 +86,7 @@ impl PlayerCharacterMetadata {
 
     const DEFAULT_GRAVITY: f32 = 1.0;
 
-    const DEFAULT_JUMP_FORCE: f32 = 9.5;
+    const DEFAULT_JUMP_FORCE: f32 = 11.5;
     const DEFAULT_MOVE_SPEED: f32 = 5.0;
     const DEFAULT_SLIDE_SPEED_FACTOR: f32 = 3.0;
     const DEFAULT_SLIDE_DURATION: f32 = 0.1;


### PR DESCRIPTION
Closes #433 .

This doesn't fix the actual issue of the jump height being slightly inconsistent, but it does make it consistently possible to get up onto the platforms that we want fish to be able to jump up to, so I think we can close #433 for now at least.