### PR TITLE
Fix 443

### DIFF
--- a/src/effects/active/mod.rs
+++ b/src/effects/active/mod.rs
@@ -1,5 +1,4 @@
 use hecs::{Entity, World};
-use macroquad::audio::play_sound_once;
 use macroquad::color;
 
 use macroquad::experimental::collections::storage;
@@ -10,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use core::math::{deg_to_rad, rotate_vector, IsZero};
 use core::Result;
 
+use crate::game::play_sound_effect;
 use crate::items::spawn_item;
 use crate::Resources;
 use crate::{PassiveEffectInstance, PassiveEffectMetadata};
@@ -53,10 +53,7 @@ pub fn spawn_active_effect(
     };
 
     if let Some(id) = &params.sound_effect_id {
-        let resources = storage::get::<Resources>();
-        let sound = resources.sounds.get(id).unwrap();
-
-        play_sound_once(*sound);
+        play_sound_effect(id, 1.0);
     }
 
     let mut damage = Vec::new();

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,5 +1,6 @@
 mod camera;
 mod music;
+pub mod sound;
 
 pub use camera::GameCamera;
 
@@ -44,6 +45,7 @@ use crate::network::{
 };
 use crate::particles::{draw_particles, update_particle_emitters};
 pub use music::{start_music, stop_music};
+pub use sound::play_sound_effect;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum GameMode {

--- a/src/game/sound.rs
+++ b/src/game/sound.rs
@@ -1,0 +1,18 @@
+use macroquad::{audio::play_sound, prelude::collections::storage};
+
+use crate::Resources;
+
+/// This is a stand-in until we have volume settings
+pub const SOUND_EFFECT_VOLUME: f32 = 0.4;
+
+pub fn play_sound_effect(sound_id: &str, volume_multiplier: f32) {
+    let resources = storage::get::<Resources>();
+    let sound = resources.sounds[sound_id];
+    play_sound(
+        sound,
+        macroquad::audio::PlaySoundParams {
+            looped: false,
+            volume: SOUND_EFFECT_VOLUME * volume_multiplier,
+        },
+    );
+}

--- a/src/items.rs
+++ b/src/items.rs
@@ -2,12 +2,13 @@
 //! Proto-mods, eventually some of the items will move to some sort of a wasm runtime
 
 use hecs::{Entity, World};
-use macroquad::audio::{play_sound_once, Sound};
+use macroquad::audio::{play_sound, PlaySoundParams, Sound};
 use macroquad::experimental::collections::storage;
 use macroquad::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
+use crate::game::sound::SOUND_EFFECT_VOLUME;
 use crate::{
     ActiveEffectMetadata, AnimatedSpriteMetadata, CollisionWorld, Drawable, PassiveEffectMetadata,
     PhysicsBody, QueuedAnimationAction, Resources,
@@ -403,7 +404,13 @@ pub fn fire_weapon(world: &mut World, entity: Entity, owner: Entity) -> Result<(
             weapon.cooldown_timer = 0.0;
 
             if let Some(sound) = weapon.sound_effect {
-                play_sound_once(sound);
+                play_sound(
+                    sound,
+                    PlaySoundParams {
+                        looped: false,
+                        volume: SOUND_EFFECT_VOLUME,
+                    },
+                );
             }
 
             let mut drawable = world.get_mut::<Drawable>(entity).unwrap();

--- a/src/map/sproinger.rs
+++ b/src/map/sproinger.rs
@@ -1,5 +1,3 @@
-use macroquad::audio::play_sound_once;
-use macroquad::experimental::collections::storage;
 use macroquad::prelude::*;
 use std::collections::HashMap;
 
@@ -8,7 +6,8 @@ use hecs::{Entity, World};
 use core::Result;
 use core::Transform;
 
-use crate::{Animation, Drawable, PhysicsBody, QueuedAnimationAction, Resources};
+use crate::game::play_sound_effect;
+use crate::{Animation, Drawable, PhysicsBody, QueuedAnimationAction};
 
 const SPROINGER_DRAW_ORDER: u32 = 2;
 
@@ -104,11 +103,6 @@ pub fn fixed_update_sproingers(world: &mut World) {
     {
         sproinger.cooldown_timer += dt;
 
-        let sound = {
-            let resources = storage::get::<Resources>();
-            resources.sounds[SOUND_EFFECT_ID]
-        };
-
         if sproinger.cooldown_timer >= COOLDOWN {
             let sprite = drawable.get_animated_sprite_mut().unwrap();
             sprite.set_animation(IDLE_ANIMATION_ID, true);
@@ -128,7 +122,7 @@ pub fn fixed_update_sproingers(world: &mut World) {
                         CONTRACT_ANIMATION_ID.to_string(),
                     ));
 
-                    play_sound_once(sound);
+                    play_sound_effect(SOUND_EFFECT_ID, 1.0);
 
                     continue 'sproingers;
                 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -70,6 +70,7 @@ pub struct Player {
     pub respawn_timer: f32,
     pub camera_box: Rect,
     pub passive_effects: Vec<PassiveEffectInstance>,
+    pub was_on_ground: bool,
 }
 
 impl Player {
@@ -83,6 +84,7 @@ impl Player {
             is_facing_left: false,
             is_upside_down: false,
             is_attacking: false,
+            was_on_ground: false,
             jump_frame_counter: 0,
             pickup_grace_timer: 0.0,
             attack_timer: 0.0,

--- a/src/player/state.rs
+++ b/src/player/state.rs
@@ -1,4 +1,3 @@
-use macroquad::audio::play_sound_once;
 use macroquad::experimental::collections::storage;
 use macroquad::prelude::*;
 
@@ -6,13 +5,12 @@ use hecs::{Entity, World};
 
 use core::Transform;
 
+use crate::game::play_sound_effect;
 use crate::player::{
     Player, PlayerAttributes, PlayerController, PlayerEventQueue, JUMP_SOUND_ID, LAND_SOUND_ID,
     RESPAWN_DELAY,
 };
-use crate::{
-    CollisionWorld, Drawable, DrawableKind, Item, Map, PhysicsBody, PlayerEvent, Resources,
-};
+use crate::{CollisionWorld, Drawable, DrawableKind, Item, Map, PhysicsBody, PlayerEvent};
 
 const SLIDE_STOP_THRESHOLD: f32 = 2.0;
 const JUMP_FRAME_COUNT: u16 = 8;
@@ -146,10 +144,7 @@ pub fn update_player_states(world: &mut World) {
 
                     player.state = PlayerState::Jumping;
 
-                    let resources = storage::get::<Resources>();
-                    let sound = resources.sounds[JUMP_SOUND_ID];
-
-                    play_sound_once(sound);
+                    play_sound_effect(JUMP_SOUND_ID, 0.4);
                 } else if player.state == PlayerState::Jumping {
                     player.jump_frame_counter += 1;
 
@@ -180,15 +175,14 @@ pub fn update_player_states(world: &mut World) {
                     player.state = PlayerState::None;
                 }
 
+                play_sound_effect(LAND_SOUND_ID, 0.4);
+
                 player.jump_frame_counter = 0;
                 body.has_mass = true;
-
-                let resources = storage::get::<Resources>();
-                let sound = resources.sounds[LAND_SOUND_ID];
-
-                play_sound_once(sound);
             }
         }
+
+        player.was_on_ground = body.is_on_ground;
     }
 }
 

--- a/src/player/state.rs
+++ b/src/player/state.rs
@@ -170,7 +170,10 @@ pub fn update_player_states(world: &mut World) {
                 }
             }
 
-            if body.is_on_ground && !body.was_on_ground {
+            // Note we can't use `body.was_on_ground` because it is only updated on fixed update,
+            // and this function may run multiple times in one fixed update, resulting in the
+            // landing sound being played more than once.
+            if body.is_on_ground && !player.was_on_ground {
                 if matches!(player.state, PlayerState::Jumping | PlayerState::Floating) {
                     player.state = PlayerState::None;
                 }


### PR DESCRIPTION
- Play Sounds a 40% volume. This is a stand-in until we have a proper
  volume settings menu, but I think having the sound effects quieter
  compared to the music is better for now.
- Also made the sounds for jumping and landing quieter than the rest
  of the sound effects, because they play very often and can become
  annoying if they are too loud.
- Fixes sound effect playing multiple times