### PR TITLE
Deny Unknown Fields Where Possible

### DIFF
--- a/assets/decoration/anemones.json
+++ b/assets/decoration/anemones.json
@@ -3,10 +3,6 @@
   "sprite": {
     "texture": "default_decoration",
     "autoplay_id": "idle",
-    "frame_size": {
-      "x": 48,
-      "y": 51
-    },
     "animations": [
       {
         "id": "idle",

--- a/assets/decoration/seaweed.json
+++ b/assets/decoration/seaweed.json
@@ -3,10 +3,6 @@
   "sprite": {
     "texture": "default_decoration",
     "autoplay_id": "idle",
-    "frame_size": {
-      "x": 48,
-      "y": 51
-    },
     "animations": [
       {
         "id": "idle",
@@ -15,7 +11,6 @@
         "fps": 8,
         "is_looping": true
       }
-    ],
-    "autoplay": true
+    ]
   }
 }

--- a/assets/items/cannon.json
+++ b/assets/items/cannon.json
@@ -46,7 +46,6 @@
           "type": "circle_collider",
           "radius": 80,
           "is_explosion": true,
-          "particle_effect": "hit",
           "sound_effect": "explode"
         },
         {

--- a/assets/items/grenades.json
+++ b/assets/items/grenades.json
@@ -60,8 +60,7 @@
             "fps": 12,
             "is_looping": true
           }
-        ],
-        "should_autoplay": true
+        ]
       },
       "particles": [
         {

--- a/assets/items/kick_bomb.json
+++ b/assets/items/kick_bomb.json
@@ -42,7 +42,6 @@
           "type": "circle_collider",
           "radius": 64,
           "is_explosion": true,
-          "particle_effect": "hit",
           "sound_effect": "explode"
         },
         {

--- a/assets/items/mines.json
+++ b/assets/items/mines.json
@@ -30,7 +30,6 @@
           "type": "circle_collider",
           "radius": 64,
           "is_explosion": true,
-          "particle_effect": "hit",
           "sound_effect": "explode"
         },
         {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -7,6 +7,7 @@ use crate::input::mapping::InputMapping;
 use crate::Result;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     pub window: WindowConfig,
@@ -32,6 +33,7 @@ impl Config {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WindowConfig {
     pub width: u32,
     pub height: u32,

--- a/core/src/input/mapping.rs
+++ b/core/src/input/mapping.rs
@@ -6,6 +6,7 @@ use crate::error::ErrorKind;
 use crate::Result;
 
 #[derive(Debug, Copy, Clone, PartialEq, Hash, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum KeyCode {
     Space,
     Apostrophe,
@@ -387,6 +388,7 @@ impl From<KeyCode> for macroquad::input::KeyCode {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum Button {
     A,
     B,
@@ -460,6 +462,7 @@ impl From<Button> for fishsticks::Button {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KeyMapping {
     primary: KeyCode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -467,6 +470,7 @@ pub struct KeyMapping {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KeyboardMapping {
     pub left: KeyCode,
     pub right: KeyCode,
@@ -504,6 +508,7 @@ impl KeyboardMapping {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GamepadMapping {
     pub id: usize,
     pub fire: Button,
@@ -532,6 +537,7 @@ impl From<&GamepadId> for GamepadMapping {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InputMapping {
     #[serde(
         default = "KeyboardMapping::default_primary",

--- a/core/src/input/mod.rs
+++ b/core/src/input/mod.rs
@@ -14,6 +14,7 @@ pub use fishsticks::GamepadContext;
 use crate::{Config, Result};
 
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlayerInput {
     pub left: bool,
     pub right: bool,

--- a/core/src/json/helpers.rs
+++ b/core/src/json/helpers.rs
@@ -19,6 +19,7 @@ pub fn is_false(val: &bool) -> bool {
 /// This can be used to wrap types in order to make serde accept both a value and a vector of
 /// values for a field, when deserializing.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum OneOrMany<T: Clone> {
     One(T),
@@ -55,6 +56,7 @@ impl<T: Clone> From<OneOrMany<T>> for Vec<T> {
 /// Furthermore, you can use `GenericParam::Vec` and `GenericParam::HashMap` to allow members of
 /// different types in the same collection, in your JSON objects.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum GenericParam {
     Bool(bool),

--- a/core/src/json/math.rs
+++ b/core/src/json/math.rs
@@ -26,6 +26,7 @@ pub mod vec2_def {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         #[serde(field_identifier, rename_all = "snake_case")]
         enum Field {
             X,
@@ -102,6 +103,7 @@ pub mod uvec2_def {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         #[serde(field_identifier, rename_all = "snake_case")]
         enum Field {
             X,
@@ -178,6 +180,7 @@ pub mod ivec2_def {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         #[serde(field_identifier, rename_all = "snake_case")]
         enum Field {
             X,
@@ -237,6 +240,7 @@ pub mod vec2_opt {
         S: Serializer,
     {
         #[derive(Serialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper<'a>(#[serde(with = "super::vec2_def")] &'a Vec2);
 
         value.as_ref().map(Helper).serialize(serializer)
@@ -247,6 +251,7 @@ pub mod vec2_opt {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper(#[serde(with = "super::vec2_def")] Vec2);
 
         let helper = Option::deserialize(deserializer)?;
@@ -263,6 +268,7 @@ pub mod vec2_vec {
         S: Serializer,
     {
         #[derive(Serialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper<'a>(#[serde(with = "super::vec2_def")] &'a Vec2);
 
         let helper: Vec<Helper> = value.iter().map(Helper).collect();
@@ -274,6 +280,7 @@ pub mod vec2_vec {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper(#[serde(with = "super::vec2_def")] Vec2);
 
         let helper = Vec::deserialize(deserializer)?;
@@ -293,6 +300,7 @@ pub mod uvec2_opt {
         S: Serializer,
     {
         #[derive(Serialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper<'a>(#[serde(with = "super::uvec2_def")] &'a UVec2);
 
         value.as_ref().map(Helper).serialize(serializer)
@@ -303,6 +311,7 @@ pub mod uvec2_opt {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper(#[serde(with = "super::uvec2_def")] UVec2);
 
         let helper = Option::deserialize(deserializer)?;
@@ -319,6 +328,7 @@ pub mod ivec2_opt {
         S: Serializer,
     {
         #[derive(Serialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper<'a>(#[serde(with = "super::ivec2_def")] &'a IVec2);
 
         value.as_ref().map(Helper).serialize(serializer)
@@ -329,6 +339,7 @@ pub mod ivec2_opt {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper(#[serde(with = "super::ivec2_def")] IVec2);
 
         let helper = Option::deserialize(deserializer)?;
@@ -337,6 +348,7 @@ pub mod ivec2_opt {
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(remote = "Rect")]
 pub struct RectDef {
     x: f32,
@@ -378,6 +390,7 @@ pub mod rect_opt {
         S: Serializer,
     {
         #[derive(Serialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper<'a>(#[serde(with = "RectDef")] &'a Rect);
 
         value.as_ref().map(Helper).serialize(serializer)
@@ -388,6 +401,7 @@ pub mod rect_opt {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper(#[serde(with = "RectDef")] Rect);
 
         let helper = Option::deserialize(deserializer)?;

--- a/core/src/json/render.rs
+++ b/core/src/json/render.rs
@@ -7,6 +7,7 @@ pub fn default_scale() -> f32 {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(remote = "Color")]
 pub struct ColorDef {
     #[serde(rename = "red", alias = "r")]
@@ -50,6 +51,7 @@ pub mod color_opt {
         S: Serializer,
     {
         #[derive(Serialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper<'a>(#[serde(with = "super::ColorDef")] &'a Color);
 
         value.as_ref().map(Helper).serialize(serializer)
@@ -60,6 +62,7 @@ pub mod color_opt {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct Helper(#[serde(with = "super::ColorDef")] Color);
 
         let helper = Option::deserialize(deserializer)?;
@@ -68,6 +71,7 @@ pub mod color_opt {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(remote = "FilterMode")]
 pub enum FilterModeDef {
     #[serde(rename = "linear")]

--- a/core/src/math.rs
+++ b/core/src/math.rs
@@ -3,6 +3,7 @@ use macroquad::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct URect {
     pub x: u32,
     pub y: u32,

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -4,6 +4,7 @@ use super::PlayerId;
 use crate::network::Lobby;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum NetworkEvent {
     LobbyCreated {

--- a/core/src/network/message.rs
+++ b/core/src/network/message.rs
@@ -5,6 +5,7 @@ use crate::input::PlayerInput;
 use super::PlayerId;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum NetworkMessage {
     UpdatePlayerInput {

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -16,6 +16,7 @@ pub type LobbyId = String;
 pub type PlayerId = String;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Server {
     pub http: SocketAddr,
     pub udp: SocketAddr,
@@ -23,6 +24,7 @@ pub struct Server {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum LobbyPrivacy {
     Public,
@@ -30,6 +32,7 @@ pub enum LobbyPrivacy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Lobby {
     pub id: LobbyId,
     pub name: String,
@@ -44,6 +47,7 @@ pub struct Lobby {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum LobbyState {
     NotStarted,
     Ready,
@@ -54,6 +58,7 @@ pub enum LobbyState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Player {
     pub id: PlayerId,
     pub username: String,
@@ -71,6 +76,7 @@ impl Player {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum ClientState {
     Unknown,
     Joined,

--- a/core/src/network/status.rs
+++ b/core/src/network/status.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum RequestStatus {
     Ok,

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum HorizontalAlignment {
     Left,
@@ -13,6 +14,7 @@ pub enum HorizontalAlignment {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum VerticalAlignment {
     Top,

--- a/src/drawables/animated_sprite.rs
+++ b/src/drawables/animated_sprite.rs
@@ -70,6 +70,7 @@ impl From<TweenMetadata> for Tween {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Keyframe {
     pub frame: u32,
     #[serde(with = "core::json::vec2_def")]
@@ -555,6 +556,7 @@ impl From<&[(&str, AnimatedSprite)]> for AnimatedSpriteSet {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnimationMetadata {
     pub id: String,
     pub row: u32,
@@ -578,12 +580,14 @@ impl From<AnimationMetadata> for MQAnimation {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TweenMetadata {
     pub id: String,
     pub keyframes: Vec<Keyframe>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnimatedSpriteMetadata {
     #[serde(rename = "texture")]
     pub texture_id: String,

--- a/src/drawables/sprite.rs
+++ b/src/drawables/sprite.rs
@@ -14,6 +14,7 @@ use crate::Resources;
 
 /// Parameters for `Sprite` component.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SpriteMetadata {
     /// The id of the texture that will be used
     #[serde(rename = "texture")]

--- a/src/effects/active/mod.rs
+++ b/src/effects/active/mod.rs
@@ -227,6 +227,8 @@ pub fn spawn_active_effect(
 
 /// This holds all the common parameters, available to all implementations, as well as specialized
 /// parameters, in the `ActiveEffectKind`.
+// NOTE: We would prefer to `serde(deny_unknown_fields)` here, but we are blocked by this issue:
+// https://github.com/serde-rs/serde/issues/1358
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ActiveEffectMetadata {
     /// This holds all the specialized parameters for the effect, dependent on the implementation,
@@ -254,6 +256,7 @@ pub struct ActiveEffectMetadata {
 /// The effects that have the `Collider` suffix denote effects that do an immediate collider check,
 /// upon attack, using the weapons `effect_offset` as origin.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ActiveEffectKind {
     /// Check for hits with a `Circle` collider.

--- a/src/effects/active/projectiles.rs
+++ b/src/effects/active/projectiles.rs
@@ -18,6 +18,7 @@ use core::Transform;
 const PROJECTILE_DRAW_ORDER: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ProjectileKind {
     Circle {

--- a/src/effects/active/triggered.rs
+++ b/src/effects/active/triggered.rs
@@ -20,6 +20,7 @@ const TRIGGERED_EFFECT_DRAW_ORDER: u32 = 5;
 
 /// The various collision types that can trigger a `TriggeredEffect`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggeredEffectTrigger {
     /// The player that deployed the effect
@@ -379,6 +380,7 @@ pub fn update_triggered_effects(world: &mut World) {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TriggeredEffectMetadata {
     /// The effects to instantiate when the triggers condition is met
     #[serde(default, alias = "effect")]
@@ -477,6 +479,7 @@ impl Default for TriggeredEffectMetadata {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TriggeredEffectGrabOptions {
     /// The size of the grab-zone
     #[serde(with = "core::json::vec2_def")]

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -9,6 +9,7 @@ pub use active::{ActiveEffectKind, ActiveEffectMetadata, TriggeredEffectTrigger}
 
 /// This is used to allow both active and passive effects to be used as values in JSON
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum AnyEffectParams {
     Active(ActiveEffectMetadata),

--- a/src/effects/passive/mod.rs
+++ b/src/effects/passive/mod.rs
@@ -101,6 +101,7 @@ impl PassiveEffectInstance {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PassiveEffectMetadata {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/items.rs
+++ b/src/items.rs
@@ -66,6 +66,7 @@ impl Default for ItemDepleteBehavior {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MapItemKind {
     Weapon {
@@ -136,6 +137,8 @@ pub struct ItemMetadata {
     pub is_hat: bool,
 }
 
+// NOTE: We would prefer to `serde(deny_unknown_fields)` here, but we are blocked by this issue:
+// https://github.com/serde-rs/serde/issues/1358
 #[derive(Clone, Serialize, Deserialize)]
 pub struct MapItemMetadata {
     pub id: String,
@@ -476,6 +479,7 @@ pub struct WeaponAnimationMetadata {
 /// This holds parameters specific to the `Weapon` variant of `ItemKind`, used to instantiate a
 /// `Weapon` struct instance, when an `Item` of type `Weapon` is picked up.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WeaponMetadata {
     /// This specifies the effects to instantiate when the weapon is used to attack
     #[serde(default)]

--- a/src/json/map/mod.rs
+++ b/src/json/map/mod.rs
@@ -13,6 +13,7 @@ use crate::map::{
 pub use tiled::TiledMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct MapDef {
     #[serde(
         default = "Map::default_background_color",
@@ -200,6 +201,7 @@ impl From<MapDef> for Map {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MapLayerDef {
     pub id: String,
     pub kind: MapLayerKind,

--- a/src/json/map/tiled.rs
+++ b/src/json/map/tiled.rs
@@ -12,6 +12,7 @@ use crate::map::{Map, MapLayer, MapLayerKind, MapObject, MapProperty, MapTile, M
 const SPAWN_POINT_MAP_OBJECT_TYPE: &str = "spawn_point";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum TiledProperty {
     Bool { name: String, value: bool },
@@ -24,6 +25,7 @@ pub enum TiledProperty {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TiledObject {
     pub id: u32,
     pub name: String,
@@ -41,6 +43,7 @@ pub struct TiledObject {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TiledTileAttribute {
     pub id: u32,
     #[serde(rename = "type")]
@@ -48,12 +51,14 @@ pub struct TiledTileAttribute {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TiledPolyPoint {
     pub x: f32,
     pub y: f32,
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TiledTileset {
     pub columns: i32,
     pub image: String,
@@ -73,6 +78,7 @@ pub struct TiledTileset {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TiledLayer {
     pub name: String,
     pub visible: bool,
@@ -87,6 +93,7 @@ pub struct TiledLayer {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TiledMap {
     // Optional background color
     pub backgroundcolor: Option<String>,

--- a/src/map/decoration.rs
+++ b/src/map/decoration.rs
@@ -10,6 +10,7 @@ use core::Transform;
 const DECORATION_DRAW_ORDER: u32 = 0;
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecorationMetadata {
     pub id: String,
     pub sprite: AnimatedSpriteMetadata,

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -33,6 +33,7 @@ const EXTRA_PLAYABLE_WIDTH: f32 = 400.0;
 pub type MapProperty = core::json::GenericParam;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MapBackgroundLayer {
     pub texture_id: String,
     pub depth: f32,
@@ -41,6 +42,7 @@ pub struct MapBackgroundLayer {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(into = "json::MapDef", from = "json::MapDef")]
 pub struct Map {
     #[serde(
@@ -455,6 +457,7 @@ impl<'a> Iterator for MapTileIterator<'a> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum MapLayerKind {
     TileLayer,
@@ -495,6 +498,7 @@ impl Default for MapLayerKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MapLayer {
     pub id: String,
     pub kind: MapLayerKind,
@@ -550,6 +554,7 @@ impl Default for MapLayer {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MapTile {
     pub tile_id: u32,
     pub tileset_id: String,
@@ -561,6 +566,7 @@ pub struct MapTile {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum MapObjectKind {
     Item,
@@ -632,6 +638,7 @@ impl ComboBoxValue for MapObjectKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MapObject {
     pub id: String,
     pub kind: MapObjectKind,
@@ -653,6 +660,7 @@ impl MapObject {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MapTileset {
     pub id: String,
     pub texture_id: String,

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -14,6 +14,7 @@ use core::Transform;
 use crate::{AnimatedSpriteMetadata, Resources};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ParticleEmitterMetadata {
     /// The id of the particle effect.
     #[serde(rename = "particle_effect")]

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -221,6 +221,7 @@ pub fn debug_draw_physics_bodies(world: &mut World) {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RigidBodyParams {
     #[serde(with = "core::json::vec2_def")]
     pub offset: Vec2,

--- a/src/player/animation.rs
+++ b/src/player/animation.rs
@@ -20,6 +20,7 @@ use crate::{Drawable, PhysicsBody};
 ///
 /// Refer to `crate::components::animation_player::AnimationParams` for detailed documentation
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlayerAnimationMetadata {
     #[serde(rename = "texture")]
     pub texture_id: String,
@@ -55,6 +56,7 @@ impl From<PlayerAnimationMetadata> for AnimatedSpriteMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlayerAnimations {
     #[serde(default = "PlayerAnimations::default_idle_animation")]
     pub idle: AnimationMetadata,

--- a/src/player/character.rs
+++ b/src/player/character.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::player::PlayerAnimationMetadata;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlayerCharacterMetadata {
     /// This is the id of the player character. This should be unique, or it will either overwrite
     /// or be overwritten, depending on load order, if not.

--- a/src/player/events.rs
+++ b/src/player/events.rs
@@ -41,6 +41,7 @@ pub enum PlayerEvent {
 
 /// This is used in JSON to specify which event types an effect should apply to
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum PlayerEventKind {
     Update,

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -44,18 +44,21 @@ const ACTIVE_MODS_FILE_NAME: &str = "active_mods";
 const MOD_FILE_NAME: &str = "fishfight_mod";
 
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ParticleEffectMetadata {
     id: String,
     path: String,
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SoundMetadata {
     id: String,
     path: String,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum TextureKind {
     Background,
@@ -64,6 +67,7 @@ pub enum TextureKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TextureMetadata {
     pub id: String,
     pub path: String,
@@ -110,6 +114,7 @@ impl From<TextureResource> for Texture2D {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ImageMetadata {
     pub id: String,
     pub path: String,
@@ -124,6 +129,7 @@ pub struct ImageResource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MapMetadata {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -581,6 +587,7 @@ pub async fn load_resources(assets_dir: &str, mods_dir: &str) -> Result<()> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModMetadata {
     pub id: String,
     #[serde(default)]
@@ -597,12 +604,14 @@ pub struct ModMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DependencyMetadata {
     pub id: String,
     pub version: String,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum ModKind {
     DataOnly,


### PR DESCRIPTION
Adds #[serde(deny_unknown_fields)] to almost all structs. We couldn't
add it to all of them because of:
https://github.com/serde-rs/serde/issues/1358

Fixes #410