### PR TITLE
Make Items And Weapons Respawn

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 use crate::effects::active::debug_draw_active_effects;
 use crate::effects::active::projectiles::fixed_update_projectiles;
 use crate::effects::active::triggered::{fixed_update_triggered_effects, update_triggered_effects};
-use crate::items::spawn_item;
+use crate::items::{spawn_item, update_respawning_items};
 use crate::map::{
     debug_draw_fish_schools, fixed_update_sproingers, spawn_crab, spawn_decoration,
     spawn_fish_school, spawn_sproinger, update_crabs, update_fish_schools, update_map_kill_zone,
@@ -118,6 +118,7 @@ impl Game {
 
         if matches!(mode, GameMode::Local | GameMode::NetworkHost) {
             updates_builder
+                .add_system(update_respawning_items)
                 .add_system(update_map_kill_zone)
                 .add_system(update_player_states)
                 .add_system(update_player_inventory)

--- a/src/items.rs
+++ b/src/items.rs
@@ -8,9 +8,10 @@ use macroquad::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
+use crate::utils::timer::Timer;
 use crate::{
-    ActiveEffectMetadata, AnimatedSpriteMetadata, CollisionWorld, Drawable, PassiveEffectMetadata,
-    PhysicsBody, QueuedAnimationAction, Resources,
+    ActiveEffectMetadata, AnimatedSpriteMetadata, CollisionWorld, Drawable, Owner,
+    PassiveEffectMetadata, PhysicsBody, QueuedAnimationAction, Resources,
 };
 
 use core::{Result, Transform};
@@ -87,8 +88,10 @@ pub struct ItemParams {
     pub drop_behavior: ItemDropBehavior,
     pub deplete_behavior: ItemDepleteBehavior,
     pub is_hat: bool,
+    pub respawn_info: Option<RespawnInfo>,
 }
 
+#[derive(Clone)]
 pub struct Item {
     pub id: String,
     pub name: String,
@@ -101,6 +104,7 @@ pub struct Item {
     pub is_hat: bool,
     pub duration_timer: f32,
     pub use_cnt: u32,
+    pub respawn_info: Option<RespawnInfo>,
 }
 
 impl Item {
@@ -114,6 +118,7 @@ impl Item {
             mount_offset: params.mount_offset,
             drop_behavior: params.drop_behavior,
             deplete_behavior: params.deplete_behavior,
+            respawn_info: params.respawn_info,
             is_hat: params.is_hat,
             duration_timer: 0.0,
             use_cnt: 0,
@@ -154,12 +159,20 @@ pub struct MapItemMetadata {
     pub drop_behavior: ItemDropBehavior,
     #[serde(default)]
     pub deplete_behavior: ItemDepleteBehavior,
+    /// If specified, the item will be respawned if it is depleted or falls off the map, after the
+    /// specified delay in seconds.
+    #[serde(default = "default_respawn_delay")]
+    pub respawn_delay: Option<f32>,
     /// This specifies the offset from the player position to where the equipped item is drawn
     #[serde(default, with = "core::json::vec2_def")]
     pub mount_offset: Vec2,
     /// The parameters for the `AnimationPlayer` that will be used to draw the item
     #[serde(alias = "animation")]
     pub sprite: AnimatedSpriteMetadata,
+}
+
+fn default_respawn_delay() -> Option<f32> {
+    Some(3.0)
 }
 
 pub fn spawn_item(world: &mut World, position: Vec2, meta: MapItemMetadata) -> Result<Entity> {
@@ -203,6 +216,10 @@ pub fn spawn_item(world: &mut World, position: Vec2, meta: MapItemMetadata) -> R
     ));
 
     let uses = meta.uses;
+    let respawn_info = meta.respawn_delay.map(|respawn_delay| RespawnInfo {
+        position,
+        respawn_delay,
+    });
 
     let name = meta.name.clone();
 
@@ -227,6 +244,7 @@ pub fn spawn_item(world: &mut World, position: Vec2, meta: MapItemMetadata) -> R
                         drop_behavior,
                         deplete_behavior,
                         is_hat,
+                        respawn_info,
                     },
                 ),
             )?;
@@ -272,6 +290,7 @@ pub fn spawn_item(world: &mut World, position: Vec2, meta: MapItemMetadata) -> R
                 effect_offset,
                 drop_behavior,
                 deplete_behavior,
+                respawn_info,
             };
 
             world.insert_one(
@@ -300,6 +319,7 @@ pub struct WeaponParams {
     pub effect_offset: Vec2,
     pub drop_behavior: ItemDropBehavior,
     pub deplete_behavior: ItemDepleteBehavior,
+    pub respawn_info: Option<RespawnInfo>,
 }
 
 impl Default for WeaponParams {
@@ -313,10 +333,12 @@ impl Default for WeaponParams {
             effect_offset: Vec2::ZERO,
             drop_behavior: Default::default(),
             deplete_behavior: Default::default(),
+            respawn_info: None,
         }
     }
 }
 
+#[derive(Clone)]
 pub struct Weapon {
     pub id: String,
     pub name: String,
@@ -332,6 +354,7 @@ pub struct Weapon {
     pub deplete_behavior: ItemDepleteBehavior,
     pub cooldown_timer: f32,
     pub use_cnt: u32,
+    pub respawn_info: Option<RespawnInfo>,
 }
 
 impl Weapon {
@@ -355,6 +378,7 @@ impl Weapon {
             effect_offset: params.effect_offset,
             drop_behavior: params.drop_behavior,
             deplete_behavior: params.deplete_behavior,
+            respawn_info: params.respawn_info,
             cooldown_timer: cooldown,
             use_cnt: 0,
         }
@@ -530,5 +554,90 @@ impl Default for WeaponMetadata {
             recoil: 0.0,
             effect_sprite: None,
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RespawnInfo {
+    pub position: Vec2,
+    pub respawn_delay: f32,
+}
+
+/// An item that has been destroyed somehow that should respawn
+#[derive(Clone)]
+pub struct RespawningItem {
+    pub timer: Timer,
+    pub info: RespawnInfo,
+    pub kind: RespawningItemKind,
+}
+
+#[derive(Clone)]
+pub enum RespawningItemKind {
+    Weapon(Weapon),
+    Item(Item),
+}
+
+pub fn update_respawning_items(world: &mut World) {
+    let mut to_spawn = Vec::new();
+
+    for (respawning_item_entity, (respawning_item, transform, body, drawable)) in world
+        .query_mut::<(
+            &mut RespawningItem,
+            &mut Transform,
+            &mut PhysicsBody,
+            &mut Drawable,
+        )>()
+    {
+        let respawning_item: &mut RespawningItem = respawning_item;
+        let transform: &mut Transform = transform;
+        let body: &mut PhysicsBody = body;
+        let drawable: &mut Drawable = drawable;
+
+        respawning_item.timer.tick_frame_time();
+
+        if respawning_item.timer.has_finished() {
+            transform.position = respawning_item.info.position;
+            body.velocity = Vec2::ZERO;
+            match &mut drawable.kind {
+                crate::DrawableKind::Sprite(s) => s.is_deactivated = false,
+                crate::DrawableKind::SpriteSet(s) => {
+                    if let Some(sprite) = s.map.get_mut(SPRITE_ANIMATED_SPRITE_ID) {
+                        sprite.is_deactivated = false;
+                    }
+                }
+                crate::DrawableKind::AnimatedSprite(s) => s.is_deactivated = false,
+                crate::DrawableKind::AnimatedSpriteSet(s) => {
+                    if let Some(sprite) = s.map.get_mut(SPRITE_ANIMATED_SPRITE_ID) {
+                        sprite.is_deactivated = false;
+                    }
+                }
+            }
+            to_spawn.push(respawning_item_entity);
+        } else {
+            match &mut drawable.kind {
+                crate::DrawableKind::Sprite(s) => s.is_deactivated = true,
+                crate::DrawableKind::SpriteSet(s) => s.deactivate_all(),
+                crate::DrawableKind::AnimatedSprite(s) => s.is_deactivated = true,
+                crate::DrawableKind::AnimatedSpriteSet(s) => s.deactivate_all(),
+            }
+        }
+    }
+
+    for entity in to_spawn {
+        let respawning_item = world.remove_one::<RespawningItem>(entity).unwrap();
+        world.remove_one::<Owner>(entity).ok();
+
+        match respawning_item.kind {
+            RespawningItemKind::Weapon(mut weapon) => {
+                weapon.use_cnt = 0;
+                world.insert_one(entity, weapon)
+            }
+            RespawningItemKind::Item(mut item) => {
+                item.use_cnt = 0;
+                item.duration_timer = 0.0;
+                world.insert_one(entity, item)
+            }
+        }
+        .unwrap();
     }
 }

--- a/src/map/player_interaction.rs
+++ b/src/map/player_interaction.rs
@@ -1,11 +1,13 @@
 use core::Transform;
 
-use hecs::World;
+use hecs::{Entity, World};
 use macroquad::prelude::collections::storage;
 
 use crate::{
+    items::{RespawnInfo, RespawningItem, RespawningItemKind, Weapon},
     player::{Player, PlayerState},
-    PhysicsBody,
+    utils::timer::Timer,
+    Item, PhysicsBody,
 };
 
 use super::Map;
@@ -13,6 +15,7 @@ use super::Map;
 pub fn update_map_kill_zone(world: &mut World) {
     let map = storage::get::<Map>();
 
+    // Kill players out of bounds
     for (_, (player, transform, body)) in world
         .query::<(&mut Player, &Transform, &PhysicsBody)>()
         .iter()
@@ -25,6 +28,83 @@ pub fn update_map_kill_zone(world: &mut World) {
 
         if !map.get_playable_area().overlaps(&player_rect) {
             player.state = PlayerState::Dead;
+        }
+    }
+
+    struct ToDestroy {
+        entity: Entity,
+        respawn_info: Option<RespawnInfo>,
+    }
+    let mut to_destroy = Vec::new();
+
+    // Despawn items out of bounds
+    for (entity, (item, transform, body)) in world
+        .query::<(&mut Item, &Transform, &PhysicsBody)>()
+        .iter()
+    {
+        let item: &mut Item = item;
+        let transform: &Transform = transform;
+        let body: &PhysicsBody = body;
+
+        let item_rect = body.as_rect(transform.position);
+
+        if !map.get_playable_area().overlaps(&item_rect) {
+            to_destroy.push(ToDestroy {
+                entity,
+                respawn_info: item.respawn_info,
+            })
+        }
+    }
+
+    // Despawn weapons out of bounds
+    for (entity, (weapon, transform, body)) in world
+        .query::<(&mut Weapon, &Transform, &PhysicsBody)>()
+        .iter()
+    {
+        let weapon: &mut Weapon = weapon;
+        let transform: &Transform = transform;
+        let body: &PhysicsBody = body;
+
+        let item_rect = body.as_rect(transform.position);
+
+        if !map.get_playable_area().overlaps(&item_rect) {
+            to_destroy.push(ToDestroy {
+                entity,
+                respawn_info: weapon.respawn_info,
+            })
+        }
+    }
+
+    for to_destroy in to_destroy {
+        let entity = to_destroy.entity;
+
+        if let Some(respawn_info) = to_destroy.respawn_info {
+            if let Ok(weapon) = world.remove_one::<Weapon>(entity) {
+                world
+                    .insert_one(
+                        entity,
+                        RespawningItem {
+                            timer: Timer::new(respawn_info.respawn_delay),
+                            info: respawn_info,
+                            kind: RespawningItemKind::Weapon(weapon),
+                        },
+                    )
+                    .unwrap();
+            } else if let Ok(item) = world.remove_one::<Item>(entity) {
+                world
+                    .insert_one(
+                        entity,
+                        RespawningItem {
+                            timer: Timer::new(respawn_info.respawn_delay),
+                            info: respawn_info,
+                            kind: RespawningItemKind::Item(item),
+                        },
+                    )
+                    .unwrap();
+            }
+        } else if let Err(err) = world.despawn(entity) {
+            #[cfg(debug_assertions)]
+            println!("WARNING: {}", err);
         }
     }
 }

--- a/src/utils/timer.rs
+++ b/src/utils/timer.rs
@@ -1,5 +1,5 @@
 /// A simple timer utility
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Timer {
     duration: f32,
     elapsed: f32,


### PR DESCRIPTION
When an item or weapon falls out of bounds or otherwise expired, they
will now respawn after three seconds by default. The respawn delay can
be modified or disabled per-item in their JSON metadata.

Fixes #438 